### PR TITLE
Find openssl executable on osx and enforce minimum required version for all platforms

### DIFF
--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -29,7 +29,7 @@ def find_openssl_executable():
     )
     if brew_openssl_prefix_result.returncode:
         raise RuntimeError('unable to find openssl from brew')
-    basepath = brew_openssl_prefix_result.stdout.decode().strip('\n')
+    basepath = brew_openssl_prefix_result.stdout.decode().rstrip()
     return os.path.join(basepath, 'bin', 'openssl')
 
 
@@ -40,7 +40,7 @@ def check_openssl_version(openssl_executable):
     )
     if openssl_version_string_result.returncode:
         raise RuntimeError('unable to invoke command: "%s"' % openssl_executable)
-    version = openssl_version_string_result.stdout.decode().strip('\n')
+    version = openssl_version_string_result.stdout.decode().rstrip()
     openssl_version_string_list = version.split(' ')
     if openssl_version_string_list[0].lower() != 'openssl':
         raise RuntimeError(

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -28,25 +28,21 @@ def find_openssl_executable():
         ['brew', '--prefix', 'openssl'],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
-    if brew_openssl_prefix_result.stderr:
+    if brew_openssl_prefix_result.returncode:
         raise RuntimeError('unable to find openssl from brew')
     basepath = brew_openssl_prefix_result.stdout.decode().strip('\n')
     return os.path.join(basepath, 'bin', 'openssl')
 
 
 def check_openssl_version(openssl_executable):
-    print('2.1')
     openssl_version_string_result = subprocess.run(
         [openssl_executable, 'version'],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
-    print('2.2')
-    if openssl_version_string_result.stderr:
-        print('unable to invoke command: "%s"' % openssl_executable, file=sys.stderr)
+    if openssl_version_string_result.returncode:
+        raise RuntimeError('unable to invoke command: "%s"' % openssl_executable)
     version = openssl_version_string_result.stdout.decode().strip('\n')
-    print('version found:\n%s' % version)
     openssl_version_string_list = version.split(' ')
-    print('2.3')
     if openssl_version_string_list[0].lower() != 'openssl':
         # TODO the message seems to not match the checked condition
         raise RuntimeError(
@@ -114,11 +110,8 @@ def run_shell_command(cmd, in_path=None):
 
 
 def create_ecdsa_param_file(path):
-    print('1')
     openssl_executable = find_openssl_executable()
-    print('2')
     check_openssl_version(openssl_executable)
-    print('3')
     run_shell_command('%s ecparam -name prime256v1 > %s' % (openssl_executable, path))
 
 

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -17,7 +17,6 @@ import os
 import platform
 import shutil
 import subprocess
-import sys
 
 
 def find_openssl_executable():

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -44,10 +44,9 @@ def check_openssl_version(openssl_executable):
     version = openssl_version_string_result.stdout.decode().strip('\n')
     openssl_version_string_list = version.split(' ')
     if openssl_version_string_list[0].lower() != 'openssl':
-        # TODO the message seems to not match the checked condition
         raise RuntimeError(
-            'expected version of the format OpenSSL '
-            '<MAJOR>.<MINOR>.<PATCH_number><PATCH_letter>  <DATE>')
+            "expected version of the format 'OpenSSL "
+            "<MAJOR>.<MINOR>.<PATCH_number><PATCH_letter>  <DATE>'")
     (major, minor, patch) = openssl_version_string_list[1].split('.')
     major = int(major)
     minor = int(minor)

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -12,10 +12,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import os
+import platform
 import shutil
 import subprocess
 import sys
+
+
+def find_openssl_executable():
+    openssl_executable = 'openssl'
+    if platform.system() == 'Darwin':
+        brew_openssl_prefix_result = subprocess.run(
+            ['brew', '--prefix', 'openssl'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        if brew_openssl_prefix_result.stderr:
+            print('unable to find openssl from brew', file=sys.stderr)
+            sys.exit(-1)
+        openssl_executable = os.path.join(brew_openssl_prefix_result.stdout.decode().strip('\n'), 'bin', 'openssl')
+    return openssl_executable
+
+
+def check_openssl_version(openssl_executable):
+    print('2.1')
+    openssl_version_string_result = subprocess.run(
+        [openssl_executable, 'version'],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    print('2.2')
+    if openssl_version_string_result.stderr:
+        print('unable to invoke command: "%s"' % openssl_executable, file=sys.stderr)
+    print('version found:\n%s' % openssl_version_string_result.stdout.decode().strip('\n'))
+    openssl_version_string_list = openssl_version_string_result.stdout.decode().strip('\n').split(' ')
+    print('2.3')
+    if openssl_version_string_list[0].lower() != 'openssl':
+        print('expected version of the format OpenSSL <MAJOR>.<MINOR>.<PATCH_number><PATCH_letter>  <DATE>')
+        sys.exit(-1)
+    (major, minor, patch) = openssl_version_string_list[1].split('.')
+    major = int(major)
+    minor = int(minor)
+    if major < 1:
+        print('need openssl 1.0.2 minimum')
+        sys.exit(-1)
+    if major == 1 and minor < 0:
+        print('need openssl 1.0.2 minimum')
+        sys.exit(-1)
+    if major == 1 and minor == 0 and int("".join(itertools.takewhile(str.isdigit, patch))) < 2:
+        print('need openssl 1.0.2 minimum')
+        sys.exit(-1)
 
 
 def create_ca_conf_file(path):
@@ -69,13 +114,20 @@ def run_shell_command(cmd, in_path=None):
 
 
 def create_ecdsa_param_file(path):
-    run_shell_command('openssl ecparam -name prime256v1 > %s' % path)
+    print('1')
+    openssl_executable = find_openssl_executable()
+    print('2')
+    check_openssl_version(openssl_executable)
+    print('3')
+    run_shell_command('%s ecparam -name prime256v1 > %s' % (openssl_executable, path))
 
 
 def create_ca_key_cert(ecdsa_param_path, ca_conf_path, ca_key_path, ca_cert_path):
+    openssl_executable = find_openssl_executable()
+    check_openssl_version(openssl_executable)
     run_shell_command(
-        'openssl req -nodes -x509 -days 3650 -newkey ec:%s -keyout %s -out %s -config %s' %
-        (ecdsa_param_path, ca_key_path, ca_cert_path, ca_conf_path))
+        '%s req -nodes -x509 -days 3650 -newkey ec:%s -keyout %s -out %s -config %s' %
+        (openssl_executable, ecdsa_param_path, ca_key_path, ca_cert_path, ca_conf_path))
 
 
 def create_governance_file(path, domain_id):
@@ -111,9 +163,11 @@ def create_governance_file(path, domain_id):
 
 
 def create_signed_governance_file(signed_gov_path, gov_path, ca_cert_path, ca_key_path):
+    openssl_executable = find_openssl_executable()
+    check_openssl_version(openssl_executable)
     run_shell_command(
-        'openssl smime -sign -in %s -text -out %s -signer %s -inkey %s' %
-        (gov_path, signed_gov_path, ca_cert_path, ca_key_path))
+        '%s smime -sign -in %s -text -out %s -signer %s -inkey %s' %
+        (openssl_executable, gov_path, signed_gov_path, ca_cert_path, ca_key_path))
 
 
 def create_keystore(args):
@@ -217,17 +271,21 @@ def create_key_and_cert_req(root, name, cnf_path, ecdsa_param_path, key_path, re
     cnf_relpath = os.path.join(name, 'request.cnf')
     key_relpath = os.path.join(name, 'key.pem')
     req_relpath = os.path.join(name, 'req.pem')
+    openssl_executable = find_openssl_executable()
+    check_openssl_version(openssl_executable)
     run_shell_command(
-        'openssl req -nodes -new -newkey ec:%s -config %s -keyout %s -out %s' %
-        (ecdsa_param_relpath, cnf_relpath, key_relpath, req_relpath), root)
+        '%s req -nodes -new -newkey ec:%s -config %s -keyout %s -out %s' %
+        (openssl_executable, ecdsa_param_relpath, cnf_relpath, key_relpath, req_relpath), root)
 
 
 def create_cert(root_path, name):
     req_relpath = os.path.join(name, "req.pem")
     cert_relpath = os.path.join(name, "cert.pem")
+    openssl_executable = find_openssl_executable()
+    check_openssl_version(openssl_executable)
     run_shell_command(
-        'openssl ca -batch -create_serial -config ca_conf.cnf -days 3650 -in %s -out %s' %
-        (req_relpath, cert_relpath), root_path)
+        '%s ca -batch -create_serial -config ca_conf.cnf -days 3650 -in %s -out %s' %
+        (openssl_executable, req_relpath, cert_relpath), root_path)
 
 
 def create_permission_file(path, name, domain_id, permissions_dict):
@@ -303,9 +361,12 @@ def get_permissions(name, policy_file_path):
 
 def create_signed_permissions_file(
         permissions_path, signed_permissions_path, ca_cert_path, ca_key_path):
+
+    openssl_executable = find_openssl_executable()
+    check_openssl_version(openssl_executable)
     run_shell_command(
-        'openssl smime -sign -in %s -text -out %s -signer %s -inkey %s' %
-        (permissions_path, signed_permissions_path, ca_cert_path, ca_key_path))
+        '%s smime -sign -in %s -text -out %s -signer %s -inkey %s' %
+        (openssl_executable, permissions_path, signed_permissions_path, ca_cert_path, ca_key_path))
 
 
 def create_permission(args):


### PR DESCRIPTION
Fixes the security issues faced during OSX testing yesterday.
Tested on Linux, OSX and Windows successfully