### PR TITLE
OS X: fix typo for env. variable

### DIFF
--- a/SROS2_MacOS.md
+++ b/SROS2_MacOS.md
@@ -28,7 +28,7 @@ In the rest of these instructions we assume that every terminal setup the enviro
 
 For OpenSSL to be found when building code you'll need to define this environment variable:
 ```bash
-export OPENSSL_ROOT_DIR=`brew prefix openssl`
+export OPENSSL_ROOT_DIR=`brew --prefix openssl`
 ```
 For convenience you can add this export to your bash_profile.
 


### PR DESCRIPTION
Silly fix for the `OPENSSL_ROOT_DIR` environment variable when using sros2 in OS X from source.