### PR TITLE
Fix access control for ardent

### DIFF
--- a/examples/sample_policy.yaml
+++ b/examples/sample_policy.yaml
@@ -3,14 +3,10 @@ nodes:
     topics:
       chatter:
         allow: s # can subscribe to chatter
-      parameter_events:
-        allow: p # can publish on parameter_events
   talker:
     topics:
       chatter:
         allow: p # can publish on chatter
-      parameter_events:
-        allow: p # can publish on parameter_events
   listener_py:
     topics:
       #'*':

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -314,18 +314,22 @@ def create_permission_file(path, name, domain_id, permissions_dict):
         # add rules for automatically created ros2 topics
         # TODO(mikaelarguedas) allow ps rules and update dictionary based on existing rule
         # if it already exists (rather than overriding the rule)
-        topic_dict['parameter_events'] = {'allow': 'p'}
+        topic_dict['parameter_events'] = {'allow': 'ps'}
         topic_dict['clock'] = {'allow': 's'}
         # we have some policies to add !
         for topic_name, policy in topic_dict.items():
-            if policy['allow'] == 's':
-                tag = 'subscribe'
+            tags = []
+            if policy['allow'] == 'ps':
+                tags = ['publish', 'subscribe']
+            elif policy['allow'] == 's':
+                tags = ['subscribe']
             elif policy['allow'] == 'p':
-                tag = 'publish'
+                tags = ['publish']
             else:
                 print("unknown permission policy '%s', skipping" % policy['allow'])
                 continue
-            permission_str += """\
+            for tag in tags:
+                permission_str += """\
         <%s>
           <partitions>
             <partition>%s</partition>

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -312,7 +312,7 @@ def create_permission_file(path, name, domain_id, permissions_dict):
     topic_dict = permissions_dict['topics']
     if topic_dict:
         # add rules for automatically created ros2 topics
-        # TODO(mikaelarguedas) allow ps rules and update dictionary based on existing rule
+        # TODO(mikaelarguedas) update dictionary based on existing rule
         # if it already exists (rather than overriding the rule)
         topic_dict['parameter_events'] = {'allow': 'ps'}
         topic_dict['clock'] = {'allow': 's'}
@@ -380,12 +380,14 @@ def create_permission_file(path, name, domain_id, permissions_dict):
         tag = 'partition'
         partition_string = \
             '<%s>' % tag + \
-            ('</%s><%s>' % (tag, tag)).join([partition for partition in service_partitions_prefix[key]]) + \
+            ('</%s><%s>' % (tag, tag)).join(
+                [partition for partition in service_partitions_prefix[key]]) + \
             '</%s>' % tag
         tag = 'topic'
         topics_string = \
             '<%s>' % tag + \
-            ('</%s><%s>' % (tag, tag)).join([(topic + key) for topic in default_parameter_topics]) + \
+            ('</%s><%s>' % (tag, tag)).join(
+                [(topic + key) for topic in default_parameter_topics]) + \
             '</%s>' % tag
         permission_str += """\
         <%s>

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -312,6 +312,7 @@ def create_permission_file(path, name, domain_id, permissions_dict):
     topic_dict = permissions_dict['topics']
     if topic_dict:
         # add rules for automatically created ros2 topics
+        # TODO(mikaelarguedas) remove this hardcoded handling for default topics
         # TODO(mikaelarguedas) update dictionary based on existing rule
         # if it already exists (rather than overriding the rule)
         topic_dict['parameter_events'] = {'allow': 'ps'}
@@ -361,6 +362,8 @@ def create_permission_file(path, name, domain_id, permissions_dict):
 """
 
     # TODO(mikaelarguedas) remove this hardcoded handling for default parameter topics
+    # TODO(mikaelarguedas) remove the need for empty partition (required for Connext at startup),
+    # see https://github.com/ros2/sros2/issues/32#issuecomment-367388140
     service_partitions_prefix = {
         'Request': ['', 'rq/%s' % name],
         'Reply': ['', 'rr/%s' % name],

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -310,6 +310,9 @@ def create_permission_file(path, name, domain_id, permissions_dict):
 """ % (name, name, domain_id)
     # access control only on topics for now
     topic_dict = permissions_dict['topics']
+    # add rules for automatically created ros2 topics
+    topic_dict['parameter_events'] = {'allow': 'p'}
+    topic_dict['clock'] = {'allow': 's'}
     if topic_dict:
         # we have some policies to add !
         for topic_name, policy in topic_dict.items():

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -310,10 +310,12 @@ def create_permission_file(path, name, domain_id, permissions_dict):
 """ % (name, name, domain_id)
     # access control only on topics for now
     topic_dict = permissions_dict['topics']
-    # add rules for automatically created ros2 topics
-    topic_dict['parameter_events'] = {'allow': 'p'}
-    topic_dict['clock'] = {'allow': 's'}
     if topic_dict:
+        # add rules for automatically created ros2 topics
+        # TODO(mikaelarguedas) allow ps rules and update dictionary based on existing rule
+        # if it already exists (rather than overriding the rule)
+        topic_dict['parameter_events'] = {'allow': 'p'}
+        topic_dict['clock'] = {'allow': 's'}
         # we have some policies to add !
         for topic_name, policy in topic_dict.items():
             if policy['allow'] == 's':

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -400,11 +400,11 @@ def create_permission_file(path, name, domain_id, permissions_dict):
 
     # DCPS* is necessary for builtin data readers
     permission_str += """\
-      <subscribe>
-        <topics>
-          <topic>DCPS*</topic>
-        </topics>
-      </subscribe>
+        <subscribe>
+          <topics>
+            <topic>DCPS*</topic>
+          </topics>
+        </subscribe>
       </allow_rule>
       <default>DENY</default>
     </grant>


### PR DESCRIPTION
connects to ros2/sros2#32

This is the minimal set of changes to get access control working for Connext with the default talker/listener.

This doesn't aim to add feature to support service Access Control. Just ensuring that the nodes can be crerated and use enforced access control for pub sub.

What this does:
- add the clock topic to allowed subscription by default
- add the parameter_events topic to allowed publications and subscriptions by default
- add publication for all default parameter service Request topics
- add subscription for all default parameter service Reply topics 