### PR TITLE
fix sample_policy download instructions

### DIFF
--- a/SROS2_Linux.md
+++ b/SROS2_Linux.md
@@ -162,7 +162,7 @@ To do this, we will use the sample policy file provided in `examples/sample_poli
 First, we will copy this sample policy file into our keystore:
 
 ```bash
-wget https://raw.githubusercontent.com/ros2/sros2/release-latest/examples/sample_policy.yaml -o ./demo_keys/policies.yaml
+curl -sk https://raw.githubusercontent.com/ros2/sros2/ardent/examples/sample_policy.yaml -o ./demo_keys/policies.yaml
 ```
 
 And now we will use it to generate the XML permission files expected by the middleware:

--- a/SROS2_MacOS.md
+++ b/SROS2_MacOS.md
@@ -128,7 +128,7 @@ To do this, we will use the sample policy file provided in `examples/sample_poli
 First, we will copy this sample policy file into our keystore:
 
 ```bash
-wget https://raw.githubusercontent.com/ros2/sros2/release-latest/examples/sample_policy.yaml -o ./demo_keys/policies.yaml
+curl -sk https://raw.githubusercontent.com/ros2/sros2/ardent/examples/sample_policy.yaml -o ./demo_keys/policies.yaml
 ```
 
 And now we will use it to generate the XML permission files expected by the middleware:

--- a/SROS2_Windows.md
+++ b/SROS2_Windows.md
@@ -108,7 +108,7 @@ To do this, we will use the sample policy file provided in `examples/sample_poli
 First, we will copy this sample policy file into our keystore:
 
 ```bash
-curl -sk https://raw.githubusercontent.com/ros2/sros2/release-latest/examples/sample_policy.yaml -o .\demo_keys\policies.yaml
+curl -sk https://raw.githubusercontent.com/ros2/sros2/ardent/examples/sample_policy.yaml -o .\demo_keys\policies.yaml
 ```
 
 And now we will use it to generate the XML permission files expected by the middleware:


### PR DESCRIPTION
needs to be ported to the ardent branch before next patch release