### PR TITLE
add missing enable_liveliness_protection tag in governance files

### DIFF
--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -148,6 +148,7 @@ def create_governance_file(path, domain_id):
                 <topic_rule>
                     <topic_expression>*</topic_expression>
                     <enable_discovery_protection>true</enable_discovery_protection>
+                    <enable_liveliness_protection>true</enable_liveliness_protection>
                     <enable_read_access_control>true</enable_read_access_control>
                     <enable_write_access_control>true</enable_write_access_control>
                     <metadata_protection_kind>ENCRYPT</metadata_protection_kind>


### PR DESCRIPTION
this tag is defined by the spec and was missing from our generated files.
Connext ignores it but Fast-RTPS parser flags the governance file as invalid if this tag is missing.

A follow up PR should be created on `test_security` to update the security files accordingly.