### PR TITLE
remove partitions

### DIFF
--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -342,9 +342,6 @@ def create_permission_file(path, name, domain_id, permissions_dict):
         </%s>
 """ % (tag, 'rt/' + topic_name, tag)
         # TODO(mikaelarguedas) remove this hardcoded handling for default parameter topics
-        # TODO(mikaelarguedas) remove the need for empty partition
-        # (required for Connext at startup),
-        # see https://github.com/ros2/sros2/issues/32#issuecomment-367388140
         service_topic_prefixes = {
             'Request': 'rq/%s/' % name,
             'Reply': 'rr/%s/' % name,

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -353,13 +353,13 @@ def create_permission_file(path, name, domain_id, permissions_dict):
             'list_parameters',
             'describe_parameters',
         ]
-        for service_direction, topic_prefix in service_topic_prefixes.items():
-            if service_direction == 'Request':
+        for topic_suffix, topic_prefix in service_topic_prefixes.items():
+            if topic_suffix == 'Request':
                 pubsubtag = 'publish'
             else:
                 pubsubtag = 'subscribe'
             service_topics = [
-                (topic_prefix + topic + service_direction) for topic in default_parameter_topics]
+                (topic_prefix + topic + topic_suffix) for topic in default_parameter_topics]
             topics_string = ''
             for service_topic in service_topics:
                 topics_string += """

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -334,20 +334,20 @@ def create_permission_file(path, name, domain_id, permissions_dict):
                 permission_str += """\
         <%s>
           <partitions>
-            <partition>%s</partition>
+            <partition></partition>
           </partitions>
           <topics>
             <topic>%s</topic>
           </topics>
         </%s>
-""" % (tag, 'rt', topic_name, tag)
+""" % (tag, 'rt/' + topic_name, tag)
         # TODO(mikaelarguedas) remove this hardcoded handling for default parameter topics
         # TODO(mikaelarguedas) remove the need for empty partition
         # (required for Connext at startup),
         # see https://github.com/ros2/sros2/issues/32#issuecomment-367388140
-        service_partitions_prefix = {
-            'Request': ['', 'rq/%s' % name],
-            'Reply': ['', 'rr/%s' % name],
+        service_topic_prefixes = {
+            'Request': 'rq/%s/' % name,
+            'Reply': 'rr/%s/' % name,
         }
         default_parameter_topics = [
             'get_parameters',
@@ -356,33 +356,27 @@ def create_permission_file(path, name, domain_id, permissions_dict):
             'list_parameters',
             'describe_parameters',
         ]
-        for key in service_partitions_prefix.keys():
+        for key, value in service_topic_prefixes.items():
             if key == 'Request':
                 pubsubtag = 'publish'
             else:
                 pubsubtag = 'subscribe'
-            tag = 'partition'
-            partition_string = \
-                '<%s>' % tag + \
-                ('</%s><%s>' % (tag, tag)).join(
-                    [partition for partition in service_partitions_prefix[key]]) + \
-                '</%s>' % tag
             tag = 'topic'
             topics_string = \
                 '<%s>' % tag + \
                 ('</%s><%s>' % (tag, tag)).join(
-                    [(topic + key) for topic in default_parameter_topics]) + \
+                    [(value + topic + key) for topic in default_parameter_topics]) + \
                 '</%s>' % tag
             permission_str += """\
         <%s>
           <partitions>
-            %s
+            <partition></partition>
           </partitions>
           <topics>
             %s
           </topics>
         </%s>
-""" % (pubsubtag, partition_string, topics_string, pubsubtag)
+""" % (pubsubtag, topics_string, pubsubtag)
 
     else:
         # no policy found: allow everything!

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -356,16 +356,17 @@ def create_permission_file(path, name, domain_id, permissions_dict):
             'list_parameters',
             'describe_parameters',
         ]
-        for key, value in service_topic_prefixes.items():
-            if key == 'Request':
+        for service_direction, topic_prefix in service_topic_prefixes.items():
+            if service_direction == 'Request':
                 pubsubtag = 'publish'
             else:
                 pubsubtag = 'subscribe'
             tag = 'topic'
+            service_topics = [
+                (topic_prefix + topic + service_direction) for topic in default_parameter_topics]
             topics_string = \
                 '<%s>' % tag + \
-                ('</%s><%s>' % (tag, tag)).join(
-                    [(value + topic + key) for topic in default_parameter_topics]) + \
+                ('</%s><%s>' % (tag, tag)).join(service_topics) + \
                 '</%s>' % tag
             permission_str += """\
         <%s>

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -367,7 +367,7 @@ def create_permission_file(path, name, domain_id, permissions_dict):
             for service_topic in service_topics:
                 topics_string += """
             <topic>
-             %s
+              %s
             </topic>""" % (service_topic)
             permission_str += """
         <%s>

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -366,9 +366,7 @@ def create_permission_file(path, name, domain_id, permissions_dict):
             topics_string = ''
             for service_topic in service_topics:
                 topics_string += """
-            <topic>
-              %s
-            </topic>""" % (service_topic)
+            <topic>%s</topic>""" % (service_topic)
             permission_str += """
         <%s>
           <partitions>

--- a/sros2/api/__init__.py
+++ b/sros2/api/__init__.py
@@ -361,20 +361,20 @@ def create_permission_file(path, name, domain_id, permissions_dict):
                 pubsubtag = 'publish'
             else:
                 pubsubtag = 'subscribe'
-            tag = 'topic'
             service_topics = [
                 (topic_prefix + topic + service_direction) for topic in default_parameter_topics]
-            topics_string = \
-                '<%s>' % tag + \
-                ('</%s><%s>' % (tag, tag)).join(service_topics) + \
-                '</%s>' % tag
-            permission_str += """\
+            topics_string = ''
+            for service_topic in service_topics:
+                topics_string += """
+            <topic>
+             %s
+            </topic>""" % (service_topic)
+            permission_str += """
         <%s>
           <partitions>
             <partition></partition>
           </partitions>
-          <topics>
-            %s
+          <topics>%s
           </topics>
         </%s>
 """ % (pubsubtag, topics_string, pubsubtag)


### PR DESCRIPTION
This moves the hack for default created topics and services from partition to topic names to match the code changes from ros2/ros2#476.

Note that this now enforces that all created topics have an empty partition

Connects to ros2/ros2#476