### PR TITLE
add logging permission profile

### DIFF
--- a/sros2/test/policies/common/node.xml
+++ b/sros2/test/policies/common/node.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <profile xmlns:xi="http://www.w3.org/2003/XInclude">
+  <xi:include href="node/logging.xml"
+    xpointer="xpointer(/profile/*)"/>
   <xi:include href="node/time.xml"
     xpointer="xpointer(/profile/*)"/>
   <xi:include href="node/parameters.xml"

--- a/sros2/test/policies/common/node/logging.xml
+++ b/sros2/test/policies/common/node/logging.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <profile>
   <topics publish="ALLOW" >
-    <topic>/rosout</topic>
+    <topic>rosout</topic>
   </topics>
 </profile>

--- a/sros2/test/policies/common/node/logging.xml
+++ b/sros2/test/policies/common/node/logging.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile>
+  <topics publish="ALLOW" >
+    <topic>/rosout</topic>
+  </topics>
+</profile>

--- a/sros2/test/policies/permissions.xml
+++ b/sros2/test/policies/permissions.xml
@@ -26,6 +26,7 @@
             <topic>rr/talker/set_parameters_atomicallyReply</topic>
             <topic>rt/chatter</topic>
             <topic>rt/parameter_events</topic>
+            <topic>rt/rosout</topic>
           </topics>
         </publish>
         <subscribe>
@@ -74,6 +75,7 @@
             <topic>rr/listener/set_parametersReply</topic>
             <topic>rr/listener/set_parameters_atomicallyReply</topic>
             <topic>rt/parameter_events</topic>
+            <topic>rt/rosout</topic>
           </topics>
         </publish>
         <subscribe>
@@ -124,6 +126,7 @@
             <topic>rr/add_two_ints_server/set_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parameters_atomicallyReply</topic>
             <topic>rt/parameter_events</topic>
+            <topic>rt/rosout</topic>
           </topics>
         </publish>
         <subscribe>
@@ -174,6 +177,7 @@
             <topic>rr/add_two_ints_client/set_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parameters_atomicallyReply</topic>
             <topic>rt/parameter_events</topic>
+            <topic>rt/rosout</topic>
           </topics>
         </publish>
         <subscribe>
@@ -228,6 +232,7 @@
             <topic>rr/minimal_action_server/set_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parameters_atomicallyReply</topic>
             <topic>rt/parameter_events</topic>
+            <topic>rt/rosout</topic>
           </topics>
         </publish>
         <subscribe>
@@ -282,6 +287,7 @@
             <topic>rr/minimal_action_client/set_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parameters_atomicallyReply</topic>
             <topic>rt/parameter_events</topic>
+            <topic>rt/rosout</topic>
           </topics>
         </publish>
         <subscribe>
@@ -346,6 +352,7 @@
             <topic>rt/fibonacci/_action/status</topic>
             <topic>rt/chatter</topic>
             <topic>rt/parameter_events</topic>
+            <topic>rt/rosout</topic>
           </topics>
         </publish>
         <subscribe>


### PR DESCRIPTION
This PR targets #72, not master

Since https://github.com/ros2/rcl/pull/350 all node need publish access to `/rosout` by default.

I called it logging in case we have other related default logging topics in the future.

@ruffsl FYI