### PR TITLE
[Issue 79] Fix permissions tutorial

### DIFF
--- a/sros2/examples/policy_definition.md
+++ b/sros2/examples/policy_definition.md
@@ -27,6 +27,6 @@ nodes:
     <node_name>:
         <ipc_type>:
             <ipc_identifier>
-                access:
-                    -<access_permissions>
+                allow:
+                    - <allow_permissions>
 ```

--- a/sros2/examples/sample_policy.yaml
+++ b/sros2/examples/sample_policy.yaml
@@ -27,10 +27,10 @@ nodes:
       #  - publish # this would allow the talker to publish on all topics
       /chatter:
         allow: 
-        -publish # allow publishing on chatter
+        - publish # allow publishing on chatter
       /chatter2:
         allow: 
-        - publish# allow publishing on chatter2
+        - publish # allow publishing on chatter2
       /chatter3:
         allow: 
-        -publish # allow publishing on chatter3
+        - publish # allow publishing on chatter3

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -422,7 +422,9 @@ def create_permission_file(path, name, domain_id, permissions_dict):
         </%s>
 """ % (tag, 'rt' + formatted_topic_name, tag)
         # TODO(mikaelarguedas) remove this hardcoded handling for default parameter topics
-        service_dict = permissions_dict['services']
+        service_dict = dict()
+        if 'services' in permissions_dict:
+            service_dict = permissions_dict['services']
         default_parameter_topics = [
             'describe_parameters',
             'get_parameters',


### PR DESCRIPTION
**Summary**
* SROS2 assumed services were included in the policy yaml file
* Format errors in the sample_policy prevented yaml parse

-----------

SROS2 is moving to xml, if a fix is required in the yaml version, here it is.

Resolves #79 

