### PR TITLE
[ros2_cmake] fix status print to match commands invoked

### DIFF
--- a/sros2_cmake/cmake/ros2_secure_node.cmake
+++ b/sros2_cmake/cmake/ros2_secure_node.cmake
@@ -16,7 +16,7 @@ macro(ros2_secure_node)
     # ros2_secure_node(NODES <node_1> <node_2>...<node_n>)
 
     # NODES (macro multi-arg) takes the node names for which keys will be generated
-    # SECURITY (cmake arg) if not define or OFF, will not generate key/keystores
+    # SECURITY (cmake arg) if not defined or OFF, will not generate key/keystores
     # ROS_SECURITY_ROOT_DIRECTORY (env variable) will the location of the keystore
     # POLICY_FILE (cmake arg) if defined, will compile policies by node name into the access private certificates (e.g POLICY_FILE=/etc/policies/<policy.xml>, Generate: <node_name> /etc/policies/<policy.xml>)
     IF (NOT SECURITY)
@@ -28,16 +28,16 @@ macro(ros2_secure_node)
     set(multiValueArgs NODES)
     cmake_parse_arguments(ros2_secure_node "" "" "${multiValueArgs}" ${ARGN} )
     foreach(node ${ros2_secure_node_NODES})
-        message(STATUS "${PROGRAM} security create_key ${SECURITY_KEYSTORE} ${node} ${policy}")
-        execute_process (
-            COMMAND ${PROGRAM} security create_key ${SECURITY_KEYSTORE} ${node} 
-        )
+        set(create_key_command "${PROGRAM} security create_key ${SECURITY_KEYSTORE} ${node}")
+        message(STATUS "Executing: ${create_key_command}")
+        execute_process(COMMAND ${create_key_command})
         if (POLICY_FILE)
             if (EXISTS ${POLICY_FILE})
                 set(policy ${POLICY_FILE})
-                message(STATUS "Executing: ${PROGRAM} security create_permission ${SECURITY_KEYSTORE} ${node} ${policy}")
+                set(create_permission_command "${PROGRAM} security create_permission ${SECURITY_KEYSTORE} ${node} ${policy}")
+                message(STATUS "Executing: ${create_permission_command}")
                 execute_process (
-                    COMMAND ${PROGRAM} security create_permission ${SECURITY_KEYSTORE} ${node} ${policy}
+                    COMMAND ${create_permission_command}
                     RESULT_VARIABLE POLICY_RESULT
                     ERROR_VARIABLE POLICY_ERROR
                     )


### PR DESCRIPTION
The status message printed for `create_key` does not match the command actually ran (additional `${policy}` argument making the command fail with `ros2: error: unrecognized arguments: foo.xml`.)

This PR uses the same string for the command and the message to avoid discrepancies in the future

---

The style of this file doesn't seem to match the [ROS 2 style guide for CMake](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#cmake). @mjcarroll @ross-desmond could we add linters to this package?