### PR TITLE
linter invocation fixup

### DIFF
--- a/sros2_cmake/CMakeLists.txt
+++ b/sros2_cmake/CMakeLists.txt
@@ -8,8 +8,7 @@ set(INCLUDE_INSTALL_DIR include/)
 set(SYSCONFIG_INSTALL_DIR share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_lint_cmake REQUIRED)
   ament_lint_cmake()
 endif()
 

--- a/sros2_cmake/CMakeLists.txt
+++ b/sros2_cmake/CMakeLists.txt
@@ -7,6 +7,8 @@ set(LIB_INSTALL_DIR lib/)
 set(INCLUDE_INSTALL_DIR include/)
 set(SYSCONFIG_INSTALL_DIR share/${PROJECT_NAME})
 
+# ament_cmake_test provides BUILD_TESTING definition
+find_package(ament_cmake_test REQUIRED)
 if(BUILD_TESTING)
   find_package(ament_cmake_lint_cmake REQUIRED)
   ament_lint_cmake()

--- a/sros2_cmake/CMakeLists.txt
+++ b/sros2_cmake/CMakeLists.txt
@@ -7,7 +7,6 @@ set(LIB_INSTALL_DIR lib/)
 set(INCLUDE_INSTALL_DIR include/)
 set(SYSCONFIG_INSTALL_DIR share/${PROJECT_NAME})
 
-find_package(ament_cmake_test REQUIRED)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/sros2_cmake/package.xml
+++ b/sros2_cmake/package.xml
@@ -10,6 +10,7 @@
 
     <buildtool_depend>cmake</buildtool_depend>
 
+    <build_depend>ament_cmake_test</build_depend>
     <build_depend>sros2</build_depend>
     <build_depend>ros2cli</build_depend>
 

--- a/sros2_cmake/package.xml
+++ b/sros2_cmake/package.xml
@@ -16,8 +16,7 @@
     <build_export_depend>sros2</build_export_depend>
     <build_export_depend>ros2cli</build_export_depend>
 
-    <test_depend>ament_lint_auto</test_depend>
-    <test_depend>ament_lint_common</test_depend>
+    <test_depend>ament_cmake_lint_cmake</test_depend>
 
     <export>
         <build_type>cmake</build_type>


### PR DESCRIPTION
Follow up of #90 

- First commit removes the (apparently) unnecessary `ament_cmake_test` find_package call.
- The second commit removes the dependency on `ament_lint_auto` altogether and only depends on `ament_cmake_lint_cmake`.

Second commit is more subjective, as this is not an ament package, each linter has to be called explicitly. At that point it seems that relying on `ament_lint_auto` loses its benefits while adding dependencies and CMake code. As this package is meant to only provide pure cmake macros it looks like `ament_lint_cmake` is the only linter it will need going forward .

Happy to revert the second commit if the ament_lint_auto approach is preferred.