### PR TITLE
fix checkout URL

### DIFF
--- a/SROS2_Linux.md
+++ b/SROS2_Linux.md
@@ -177,7 +177,7 @@ To do this, we will use the sample policy file provided in `examples/sample_poli
 First, we will copy this sample policy file into our keystore:
 
 ```bash
-svn checkout https://github.com/ros2/sros2/trunk/sros2/sros2/test/policies
+svn checkout https://github.com/ros2/sros2/trunk/sros2/test/policies
 ```
 
 And now we will use it to generate the XML permission files expected by the middleware:

--- a/SROS2_MacOS.md
+++ b/SROS2_MacOS.md
@@ -143,7 +143,7 @@ To do this, we will use the sample policy file provided in `examples/sample_poli
 First, we will copy this sample policy file into our keystore:
 
 ```bash
-svn checkout https://github.com/ros2/sros2/trunk/sros2/sros2/test/policies
+svn checkout https://github.com/ros2/sros2/trunk/sros2/test/policies
 ```
 
 And now we will use it to generate the XML permission files expected by the middleware:

--- a/SROS2_Windows.md
+++ b/SROS2_Windows.md
@@ -129,7 +129,7 @@ To do this, we will use the sample policy file provided in `examples/sample_poli
 First, we will copy this sample policy file into our keystore:
 
 ```bat
-svn checkout https://github.com/ros2/sros2/trunk/sros2/sros2/test/policies
+svn checkout https://github.com/ros2/sros2/trunk/sros2/test/policies
 ```
 
 And now we will use it to generate the XML permission files expected by the middleware:


### PR DESCRIPTION
Without the patch:
```
$ svn checkout https://github.com/ros2/sros2/trunk/sros2/sros2/test/policies
svn: E170000: URL 'https://github.com/ros2/sros2/trunk/sros2/sros2/test/policies' doesn't exist
```

with the patch:

```
$ svn checkout https://github.com/ros2/sros2/trunk/sros2/test/policies
A    policies/add_two_ints.xml
A    policies/common
A    policies/common/node.xml
A    policies/common/node
A    policies/common/node/logging.xml
A    policies/common/node/parameters.xml
A    policies/common/node/time.xml
A    policies/minimal_action.xml
A    policies/permissions.xml
A    policies/policy_to_permissions.py
A    policies/sample_policy.xml
A    policies/talker_listener.xml
Checked out revision 273.
```