### PR TITLE
[sros2_cmake] remove unnecessary build dependencies

### DIFF
--- a/sros2_cmake/package.xml
+++ b/sros2_cmake/package.xml
@@ -11,8 +11,6 @@
     <buildtool_depend>cmake</buildtool_depend>
 
     <build_depend>ament_cmake_test</build_depend>
-    <build_depend>sros2</build_depend>
-    <build_depend>ros2cli</build_depend>
 
     <build_export_depend>sros2</build_export_depend>
     <build_export_depend>ros2cli</build_export_depend>


### PR DESCRIPTION
As these dependencies are used in the provided CMake macros but not needed for the build step of this package