### PR TITLE
make sros2_cmake an ament package

### DIFF
--- a/sros2_cmake/CMakeLists.txt
+++ b/sros2_cmake/CMakeLists.txt
@@ -1,32 +1,18 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(sros2_cmake)
-set(VERSION "1.0.0")
 
-include(CMakePackageConfigHelpers)
-set(LIB_INSTALL_DIR lib/)
-set(INCLUDE_INSTALL_DIR include/)
-set(SYSCONFIG_INSTALL_DIR share/${PROJECT_NAME})
+find_package(ament_cmake REQUIRED)
 
-# ament_cmake_test provides BUILD_TESTING definition
-find_package(ament_cmake_test REQUIRED)
 if(BUILD_TESTING)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  ament_lint_cmake()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
-configure_package_config_file(sros2_cmakeConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/sros2_cmakeConfig.cmake
-  INSTALL_DESTINATION ${LIB_INSTALL_DIR}/sros2_cmake/cmake
-  PATH_VARS INCLUDE_INSTALL_DIR SYSCONFIG_INSTALL_DIR
+ament_package(
+  CONFIG_EXTRAS "sros2_cmake-extras.cmake"
 )
 
-write_basic_package_version_file(
-  ${CMAKE_CURRENT_BINARY_DIR}/sros2_cmakeConfigVersion.cmake
-  VERSION ${VERSION}
-  COMPATIBILITY SameMajorVersion
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
 )
-
-install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake DESTINATION share/${PROJECT_NAME}/cmake)
-install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake DESTINATION share/${PROJECT_NAME}/cmake)
-install(FILES cmake/ros2_secure_node.cmake DESTINATION share/${PROJECT_NAME}/cmake)
-install(FILES cmake/ros2_create_keystore.cmake DESTINATION share/${PROJECT_NAME}/cmake)

--- a/sros2_cmake/package.xml
+++ b/sros2_cmake/package.xml
@@ -8,7 +8,7 @@
     <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
     <license>Apache 2.0</license>
 
-    <buildtool_depend>cmake</buildtool_depend>
+    <buildtool_depend>ament_cmake</buildtool_depend>
 
     <build_depend>ament_cmake_test</build_depend>
     <build_depend>sros2</build_depend>
@@ -17,9 +17,10 @@
     <build_export_depend>sros2</build_export_depend>
     <build_export_depend>ros2cli</build_export_depend>
 
-    <test_depend>ament_cmake_lint_cmake</test_depend>
+    <test_depend>ament_lint_auto</test_depend>
+    <test_depend>ament_lint_common</test_depend>
 
     <export>
-        <build_type>cmake</build_type>
+        <build_type>ament_cmake</build_type>
     </export>
 </package>

--- a/sros2_cmake/sros2_cmake-extras.cmake
+++ b/sros2_cmake/sros2_cmake-extras.cmake
@@ -1,0 +1,19 @@
+# Copyright 2019 Open Source Robotics Foundation Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(DEFAULT_KEYSTORE keys)
+
+include("${sros2_cmake_DIR}/ros2_create_keystore.cmake")
+include("${sros2_cmake_DIR}/ros2_secure_node.cmake")
+

--- a/sros2_cmake/sros2_cmakeConfig.cmake.in
+++ b/sros2_cmake/sros2_cmakeConfig.cmake.in
@@ -1,9 +1,0 @@
-# Compute paths
-
-set(DEFAULT_KEYSTORE keys)
-set(ros2_security_helperBASE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
-set(DEFAULT_SECURE_FOLDER "${ros2_security_helperBASE_DIR}/ros2_security")
-
-include("${CMAKE_CURRENT_LIST_DIR}/ros2_secure_node.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/ros2_create_keystore.cmake")
-


### PR DESCRIPTION
Currently the fact that this is a pure CMake package causes some inconsistencies/issues.
The package does not install it's package.xml, nor it registers itself in the ament index. This causes the package to not be detected by the ros2 tools (e.g. `ros2 pkg` or `rosdep`) requiring workarounds for downstream users (e.g https://github.com/Karsten1987/roscon2018/blob/c045d9490e4e80a9ada1ed3cb1e077f268667409/.travis/ci_script.bash#L11).
And some minor issues like mismatching version number (package.xml says 0.6.2 while CMakeLists says 1.0.0).

It seems to me that it would be easier to leverage `ament_cmake` to do the boilerplate rather than manually doing the logic of file installation and package registration, so this PR converts `sros2_cmake` into an ament package.