### PR TITLE
place default keystore to install space

### DIFF
--- a/sros2_cmake/sros2_cmake-extras.cmake
+++ b/sros2_cmake/sros2_cmake-extras.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(DEFAULT_KEYSTORE keys)
+set(DEFAULT_KEYSTORE "${CMAKE_INSTALL_PREFIX}/ros2_security/keystore")
 
 include("${sros2_cmake_DIR}/ros2_create_keystore.cmake")
 include("${sros2_cmake_DIR}/ros2_secure_node.cmake")


### PR DESCRIPTION
This PR implements the keystore location in install space, based on discussion from https://github.com/ros2/sros2/pull/101#discussion_r266210251

The original implementation aimed at creating the default keystore in the `sros2_cmake` workspace install space under a `ros2_security` directory.

https://github.com/ross-desmond/sros2/blob/51fd900a1665bd6a4d760aa501488401f32946f3/sros2_cmake/sros2_cmakeConfig.cmake.in#L3-L5

In the case of installing from packages, this logic results in creating the keystore at `/opt/ros/crystal/share/sros2_cmake/cmake/../../../ros2_security` (which requires root access).

Changes from original implementation:
- keystore is created in the current worskpace installation location
  - this requires the same permissions as the other install targets
  - is robust to the installation layout of `sros2_cmake`'s workspace (aka results in the same directory whether the underlay was built in isolated install or merged install layout)
- the keystore folder `keys` is renamed `keystore`

@ross-desmond 
Does this match the expected behavior?
What files do we expect to be placed in the `ros2_security` folders other than the keystore? (user policy files maybe?). If none maybe 1 layer of subdirectory would be enough