### PR TITLE
Guard against invalid key names

### DIFF
--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -10,6 +10,7 @@
   <author email="morgan@osrfoundation.org">Morgan Quigley</author>
   <author>Mikael Arguedas</author>
 
+  <depend>rclpy</depend>
   <depend>ros2cli</depend>
 
   <exec_depend>openssl</exec_depend>

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -298,7 +298,12 @@ def is_valid_keystore(path):
 
 def is_key_name_valid(name):
     # quick check for obvious filesystem problems
-    return ('..' not in name) and ('\\' not in name) and (name.startswith('/'))
+    if ('..' in name) or ('\\' in name) or (not name.startswith('/')):
+        return False
+    # name must contain characters other than whitespace and '/'
+    if not name.strip('/ '):
+        return False
+    return True
 
 
 def create_request_file(path, name):
@@ -418,7 +423,7 @@ def create_key(keystore_path, identity):
         print("'%s' is not a valid keystore " % keystore_path)
         return False
     if not is_key_name_valid(identity):
-        print("bad character in requested identity: '%s'" % identity)
+        print("'%s' is not a valid key name" % identity)
         return False
     print("creating key for identity: '%s'" % identity)
 

--- a/sros2/test/api/test_api.py
+++ b/sros2/test/api/test_api.py
@@ -1,0 +1,32 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sros2.api import is_key_name_valid
+
+
+def test_is_key_name_valid():
+    # Valid cases
+    assert is_key_name_valid('/foo')
+    assert is_key_name_valid('/foo/bar')
+    assert is_key_name_valid('/foo/bar123/_/baz_')
+
+    # Invalid cases
+    assert not is_key_name_valid('')
+    assert not is_key_name_valid(' ')
+    assert not is_key_name_valid('/')
+    assert not is_key_name_valid('//')
+    assert not is_key_name_valid('foo')
+    assert not is_key_name_valid('foo/bar')
+    assert not is_key_name_valid('/42foo')
+    assert not is_key_name_valid('/foo/42bar')

--- a/sros2/test/sros2/test_api.py
+++ b/sros2/test/sros2/test_api.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
In particular, guard against keys that only consist of whitespace and '/' characters.
The error message is also improved slightly.

Fixes #113 