### PR TITLE
Remove use of subprocess for creating ca key and cert

### DIFF
--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -331,7 +331,6 @@ def create_keystore(keystore_path):
 
 def is_valid_keystore(path):
     res = os.path.isfile(os.path.join(path, 'ca_conf.cnf'))
-    res &= os.path.isfile(os.path.join(path, 'ecdsaparam'))
     res &= os.path.isfile(os.path.join(path, 'index.txt'))
     res &= os.path.isfile(os.path.join(path, 'ca.key.pem'))
     res &= os.path.isfile(os.path.join(path, 'ca.cert.pem'))

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -122,7 +122,7 @@ def check_openssl_version(openssl_executable):
         raise RuntimeError('need openssl 1.0.2 minimum')
 
 
-def write_key(
+def _write_key(
     key,
     key_path,
     *,
@@ -137,7 +137,7 @@ def write_key(
             encryption_algorithm=encryption_algorithm))
 
 
-def write_cert(cert, cert_path, *, encoding=serialization.Encoding.PEM):
+def _write_cert(cert, cert_path, *, encoding=serialization.Encoding.PEM):
     with open(cert_path, 'wb') as f:
         f.write(cert.public_bytes(encoding=encoding))
 
@@ -216,8 +216,9 @@ def create_ecdsa_param_file(path):
 
 
 def create_ca_key_cert(ca_key_out_path, ca_cert_out_path):
+    # DDS-Security 9.3.1 calls for prime256v1 - SECP256R1 is another alias for that
     private_key = ec.generate_private_key(ec.SECP256R1, cryptography_backend())
-    write_key(private_key, ca_key_out_path)
+    _write_key(private_key, ca_key_out_path)
 
     common_name = x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, u'sros2testCA')
     builder = x509.CertificateBuilder(
@@ -237,7 +238,7 @@ def create_ca_key_cert(ca_key_out_path, ca_cert_out_path):
             x509.BasicConstraints(ca=True, path_length=1), critical=True
         )
     cert = builder.sign(private_key, hashes.SHA256(), cryptography_backend())
-    write_cert(cert, ca_cert_out_path)
+    _write_cert(cert, ca_cert_out_path)
 
 
 def create_governance_file(path, domain_id):

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -125,6 +125,7 @@ def check_openssl_version(openssl_executable):
 def write_key(
     key,
     key_path,
+    *,
     encoding=serialization.Encoding.PEM,
     format=serialization.PrivateFormat.PKCS8,
     encryption_algorithm=serialization.NoEncryption()
@@ -136,7 +137,7 @@ def write_key(
             encryption_algorithm=encryption_algorithm))
 
 
-def write_cert(cert, cert_path, encoding=serialization.Encoding.PEM):
+def write_cert(cert, cert_path, *, encoding=serialization.Encoding.PEM):
     with open(cert_path, 'wb') as f:
         f.write(cert.public_bytes(encoding=encoding))
 
@@ -219,14 +220,22 @@ def create_ca_key_cert(ca_key_out_path, ca_cert_out_path):
     write_key(private_key, ca_key_out_path)
 
     common_name = x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, u'sros2testCA')
-    builder = x509.CertificateBuilder()\
-        .issuer_name(x509.Name([common_name])) \
-        .serial_number(x509.random_serial_number()) \
-        .not_valid_before(datetime.datetime.today() - datetime.timedelta(days=1)) \
-        .not_valid_after(datetime.datetime.today() + datetime.timedelta(days=3650)) \
-        .public_key(private_key.public_key()) \
-        .subject_name(x509.Name([common_name])) \
-        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+    builder = x509.CertificateBuilder(
+        ).issuer_name(
+            x509.Name([common_name])
+        ).serial_number(
+            x509.random_serial_number()
+        ).not_valid_before(
+            datetime.datetime.today() - datetime.timedelta(days=1)
+        ).not_valid_after(
+            datetime.datetime.today() + datetime.timedelta(days=3650)
+        ).public_key(
+            private_key.public_key()
+        ).subject_name(
+            x509.Name([common_name])
+        ).add_extension(
+            x509.BasicConstraints(ca=True, path_length=1), critical=True
+        )
     cert = builder.sign(private_key, hashes.SHA256(), cryptography_backend())
     write_cert(cert, ca_cert_out_path)
 

--- a/sros2/test/sros2/commands/security/verbs/test_create_keystore.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_keystore.py
@@ -53,13 +53,6 @@ def test_create_keystore():
             ' root_ca_extensions ',
         ]
 
-    def check_ecdsaparam(path):
-        with open(path, 'r') as f:
-            # cryptography does not seem to know how to load ecparams
-            lines = f.readlines()
-            assert lines[0] == '-----BEGIN EC PARAMETERS-----\n'
-            assert lines[-1] == '-----END EC PARAMETERS-----\n'
-
     def check_governance_xml(path):
         # validates valid XML
         ElementTree.parse(path)
@@ -77,7 +70,6 @@ def test_create_keystore():
             ('index.txt', check_index_txt),
             ('ca.cert.pem', check_ca_cert_pem),
             ('ca_conf.cnf', check_ca_conf),
-            ('ecdsaparam', check_ecdsaparam),
             ('governance.xml', check_governance_xml),
             ('ca.key.pem', check_ca_key_pem),
             ('serial', None),


### PR DESCRIPTION
Depends on https://github.com/ros2/sros2/pull/124

Removes first instance of `run_shell_command` subprocess call, beginning the fix for https://github.com/ros2/sros2/issues/109 

Signed-off-by: Emerson Knapp <eknapp@amazon.com>