### PR TITLE
Move security policy building into API module 

### DIFF
--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -33,6 +33,7 @@ from sros2.policy import (
     get_transport_schema,
     get_transport_template,
     load_policy,
+    POLICY_VERSION,
 )
 
 HIDDEN_NODE_PREFIX = '_'
@@ -551,3 +552,55 @@ def generate_artifacts(keystore_path=None, identity_names=[], policy_files=[]):
             create_permissions_from_policy_element(
                 keystore_path, identity_name, policy_element)
     return True
+
+
+class PolicyBuilder(object):
+    """Load and modify an XML security policy."""
+    def __init__(self, policy_file_path):
+        if os.path.isfile(policy_file_path):
+            self.policy = load_policy(policy_file_path)
+        else:
+            profiles = etree.Element('profiles')
+            self.policy = etree.Element('policy')
+            self.policy.attrib['version'] = POLICY_VERSION
+            self.policy.append(profiles)
+
+    def get_profile(self, node_name):
+        profile = self.policy.find(
+            path='profiles/profile[@ns="{ns}"][@node="{node}"]'.format(
+                ns=node_name.ns,
+                node=node_name.node))
+        if profile is None:
+            profile = etree.Element('profile')
+            profile.attrib['ns'] = node_name.ns
+            profile.attrib['node'] = node_name.node
+            profiles = self.policy.find('profiles')
+            profiles.append(profile)
+        return profile
+
+    def get_permissions(self, profile, permission_type, rule_type, rule_qualifier):
+        permissions = profile.find(
+            path='{permission_type}s[@{rule_type}="{rule_qualifier}"]'.format(
+                permission_type=permission_type,
+                rule_type=rule_type,
+                rule_qualifier=rule_qualifier))
+        if permissions is None:
+            permissions = etree.Element(permission_type + 's')
+            permissions.attrib[rule_type] = rule_qualifier
+            profile.append(permissions)
+        return permissions
+
+    def add_permission(
+            self, profile, permission_type, rule_type, rule_qualifier, expressions, node_name):
+        permissions = self.get_permissions(profile, permission_type, rule_type, rule_qualifier)
+        for expression in expressions:
+            permission = etree.Element(permission_type)
+            if expression.fqn.startswith(node_name.fqn + '/'):
+                permission.text = '~' + expression.fqn[len(node_name.fqn + '/'):]
+            elif expression.fqn.startswith(node_name.ns + '/'):
+                permission.text = expression.fqn[len(node_name.ns + '/'):]
+            elif expression.fqn.count('/') == 1 and node_name.ns == '/':
+                permission.text = expression.fqn[len('/'):]
+            else:
+                permission.text = expression.fqn
+            permissions.append(permission)


### PR DESCRIPTION
Move security policy building so that it can be more easily reused outside the CLI verb. This specifically enables writing a better `create_permission` test, so we don't have to call the CLI in that test.