### PR TITLE
create_key test: add missing tests

### DIFF
--- a/sros2/test/sros2/commands/security/verbs/test_create_key.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_key.py
@@ -102,8 +102,6 @@ def test_cert_pem(node_keys_dir):
 
 
 def test_ecdsaparam(node_keys_dir):
-    # Would really like to verify the signature, but ffi just can't use
-    # that part of the OpenSSL API
     with open(os.path.join(node_keys_dir, 'ecdsaparam')) as f:
         assert f.read() == textwrap.dedent("""\
             -----BEGIN EC PARAMETERS-----

--- a/sros2/test/sros2/commands/security/verbs/test_create_key.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_key.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import configparser
 import os
-import tempfile
+import textwrap
 from xml.etree import ElementTree
 
 import cryptography
@@ -22,9 +23,27 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from ros2cli import cli
+import pytest
 
+from ros2cli import cli
 from sros2.api import create_keystore
+
+
+# This fixture will run once for the entire module (as opposed to once per test)
+@pytest.fixture(scope='module')
+def node_keys_dir(tmp_path_factory):
+    keystore_dir = str(tmp_path_factory.mktemp('keystore'))
+
+    # First, create the keystore
+    assert create_keystore(keystore_dir)
+
+    # Now using that keystore, create a keypair along with other files required by DDS
+    assert cli.main(argv=['security', 'create_key', keystore_dir, '/test_node']) == 0
+    node_dir = os.path.join(keystore_dir, 'test_node')
+    assert os.path.isdir(os.path.join(keystore_dir, 'test_node'))
+
+    # Return path to directory containing the node's files
+    return node_dir
 
 
 def load_cert(path):
@@ -62,69 +81,106 @@ def verify_signature(cert, signatory):
     return True
 
 
-def check_cert_pem(path, signatory):
-    cert = load_cert(path)
+def test_create_key(node_keys_dir):
+    expected_files = (
+        'cert.pem', 'ecdsaparam', 'governance.p7s', 'identity_ca.cert.pem', 'key.pem',
+        'permissions.p7s', 'permissions.xml', 'permissions_ca.cert.pem', 'req.pem', 'request.cnf'
+    )
+    assert len(os.listdir(node_keys_dir)) == len(expected_files)
+
+    for expected_file in expected_files:
+        assert os.path.isfile(os.path.join(node_keys_dir, expected_file))
+
+
+def test_cert_pem(node_keys_dir):
+    cert = load_cert(os.path.join(node_keys_dir, 'cert.pem'))
     check_common_name(cert.subject, u'/test_node')
     check_common_name(cert.issuer, u'sros2testCA')
+
+    signatory = load_cert(os.path.join(node_keys_dir, 'identity_ca.cert.pem'))
     assert verify_signature(cert, signatory)
 
 
-def check_permissions_xml(path, signatory):
-    ElementTree.parse(path)
+def test_ecdsaparam(node_keys_dir):
+    # Would really like to verify the signature, but ffi just can't use
+    # that part of the OpenSSL API
+    with open(os.path.join(node_keys_dir, 'ecdsaparam')) as f:
+        assert f.read() == textwrap.dedent("""\
+            -----BEGIN EC PARAMETERS-----
+            BggqhkjOPQMBBw==
+            -----END EC PARAMETERS-----
+            """)
 
 
-def check_permissions_ca_cert_pem(path, signatory):
-    cert = load_cert(path)
+def test_governance_p7s(node_keys_dir):
+    # Would really like to verify the signature, but ffi just can't use
+    # that part of the OpenSSL API
+    with open(os.path.join(node_keys_dir, 'governance.p7s')) as f:
+        lines = f.readlines()
+        assert lines[0] == 'MIME-Version: 1.0\n'
+        assert lines[1].startswith(
+            'Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256";')  # noqa
+
+
+def test_identity_ca_cert_pem(node_keys_dir):
+    cert = load_cert(os.path.join(node_keys_dir, 'identity_ca.cert.pem'))
     check_common_name(cert.subject, u'sros2testCA')
     check_common_name(cert.issuer, u'sros2testCA')
-    assert verify_signature(cert, signatory)
 
 
-def check_req_pem(path, signatory):
-    csr = load_csr(path)
-    check_common_name(csr.subject, u'/test_node')
-
-
-def check_key_pem(path, signatory):
-    private_key = load_private_key(path)
+def test_key_pem(node_keys_dir):
+    private_key = load_private_key(os.path.join(node_keys_dir, 'key.pem'))
     public_key = private_key.public_key()
     assert isinstance(public_key.curve, ec.SECP256R1)
 
 
-def check_identity_ca_cert_pem(path):
-    cert = load_cert(path)
+def test_permissions_p7s(node_keys_dir):
+    # Would really like to verify the signature, but ffi just can't use
+    # that part of the OpenSSL API
+    with open(os.path.join(node_keys_dir, 'permissions.p7s')) as f:
+        lines = f.readlines()
+        assert lines[0] == 'MIME-Version: 1.0\n'
+        assert lines[1].startswith(
+            'Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256";')  # noqa
+
+
+def test_permissions_xml(node_keys_dir):
+    ElementTree.parse(os.path.join(node_keys_dir, 'permissions.xml'))
+
+
+def test_permissions_ca_cert_pem(node_keys_dir):
+    cert = load_cert(os.path.join(node_keys_dir, 'permissions_ca.cert.pem'))
     check_common_name(cert.subject, u'sros2testCA')
     check_common_name(cert.issuer, u'sros2testCA')
-    return cert
+
+    signatory = load_cert(os.path.join(node_keys_dir, 'identity_ca.cert.pem'))
+    assert verify_signature(cert, signatory)
 
 
-def test_create_key():
-    with tempfile.TemporaryDirectory() as keystore_dir:
-        # First, create the keystore
-        assert create_keystore(keystore_dir)
+def test_req_pem(node_keys_dir):
+    csr = load_csr(os.path.join(node_keys_dir, 'req.pem'))
+    check_common_name(csr.subject, u'/test_node')
 
-        # Now using that keystore, create a keypair
-        assert cli.main(argv=['security', 'create_key', keystore_dir, '/test_node']) == 0
-        assert os.path.isdir(os.path.join(keystore_dir, 'test_node'))
 
-        expected_files = (
-            ('cert.pem', check_cert_pem),
-            ('permissions.xml', check_permissions_xml),
-            ('permissions_ca.cert.pem', check_permissions_ca_cert_pem),
-            ('request.cnf', None),
-            ('req.pem', check_req_pem),
-            ('permissions.p7s', None),
-            ('key.pem', check_key_pem),
-            ('governance.p7s', None),
-            ('ecdsaparam', None),
-        )
+def test_request_cnf(node_keys_dir):
+    config = configparser.ConfigParser()
 
-        signatory_path = os.path.join(keystore_dir, 'test_node', 'identity_ca.cert.pem')
-        assert os.path.isfile(signatory_path)
-        signatory = check_identity_ca_cert_pem(signatory_path)
+    # ConfigParser doesn't support INI files without section headers, so pretend one
+    # is there
+    with open(os.path.join(node_keys_dir, 'request.cnf')) as f:
+        config.read_string('[root]\n' + f.read())
 
-        for expected_file, file_validator in expected_files:
-            path = os.path.join(keystore_dir, 'test_node', expected_file)
-            assert os.path.isfile(path)
-            if file_validator:
-                file_validator(path, signatory)
+    for expected_section in ('root', ' req_distinguished_name '):
+        assert expected_section in config.sections()
+
+    root_config = config['root']
+    for expected_root_key in ('prompt', 'string_mask', 'distinguished_name'):
+        assert expected_root_key in root_config
+
+    assert root_config['prompt'] == 'no'
+    assert root_config['string_mask'] == 'utf8only'
+    assert root_config['distinguished_name'] == 'req_distinguished_name'
+
+    req_config = config[' req_distinguished_name ']
+    assert 'commonName' in req_config
+    assert req_config['commonName'] == '/test_node'


### PR DESCRIPTION
In preparation for future work, this PR adds a few tests that are missing from `create_key`, specifically tests that verify the request.cnf, permissions.p7s, governance.p7s, and ecdsaparam.

Also rework test module to use module fixtures and multiple smaller test cases instead of one large one. This makes it easier to add more, and makes test failures more meaningful.

cc @jacobperron, @emersonknapp 