### PR TITLE
Follow up 126: factor out hardcoded common name

### DIFF
--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -44,14 +44,14 @@ from sros2.policy import (
 HIDDEN_NODE_PREFIX = '_'
 DOMAIN_ID_ENV = 'ROS_DOMAIN_ID'
 
-NodeName = namedtuple('NodeName', ('node', 'ns', 'fqn'))
-TopicInfo = namedtuple('Topic', ('fqn', 'type'))
+NODE_NAME = namedtuple('NodeName', ('node', 'ns', 'fqn'))
+TOPIC_INFO = namedtuple('Topic', ('fqn', 'type'))
 
 
 def get_node_names(*, node, include_hidden_nodes=False):
     node_names_and_namespaces = node.get_node_names_and_namespaces()
     return [
-        NodeName(
+        NODE_NAME(
             node=t[0],
             ns=t[1],
             fqn=t[1] + ('' if t[1].endswith('/') else '/') + t[0])
@@ -66,7 +66,7 @@ def get_node_names(*, node, include_hidden_nodes=False):
 def get_topics(node_name, func):
     names_and_types = func(node_name.node, node_name.ns)
     return [
-        TopicInfo(
+        TOPIC_INFO(
             fqn=t[0],
             type=t[1])
         for t in names_and_types]

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -46,7 +46,7 @@ from sros2.policy import (
 HIDDEN_NODE_PREFIX = '_'
 DOMAIN_ID_ENV = 'ROS_DOMAIN_ID'
 
-DEFAULT_COMMON_NAME = 'sros2testCA'
+_DEFAULT_COMMON_NAME = 'sros2testCA'
 
 NodeName = namedtuple('NodeName', ('node', 'ns', 'fqn'))
 TopicInfo = namedtuple('Topic', ('fqn', 'type'))
@@ -204,7 +204,7 @@ def create_ca_conf_file(path):
 
         [ root_ca_extensions ]
         basicConstraints = CA:true
-        """.format(common_name=DEFAULT_COMMON_NAME))
+        """.format(common_name=_DEFAULT_COMMON_NAME))
     with open(path, 'w') as f:
         f.write(conf_string)
 
@@ -225,7 +225,7 @@ def create_ca_key_cert(ca_key_out_path, ca_cert_out_path):
     private_key = ec.generate_private_key(ec.SECP256R1, cryptography_backend())
     _write_key(private_key, ca_key_out_path)
 
-    common_name = x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, DEFAULT_COMMON_NAME)
+    common_name = x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, _DEFAULT_COMMON_NAME)
     builder = x509.CertificateBuilder(
         ).issuer_name(
             x509.Name([common_name])

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -129,13 +129,13 @@ def _write_key(
     key_path,
     *,
     encoding=serialization.Encoding.PEM,
-    format=serialization.PrivateFormat.PKCS8,
+    serialization_format=serialization.PrivateFormat.PKCS8,
     encryption_algorithm=serialization.NoEncryption()
 ):
     with open(key_path, 'wb') as f:
         f.write(key.private_bytes(
             encoding=encoding,
-            format=format,
+            format=serialization_format,
             encryption_algorithm=encryption_algorithm))
 
 

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -20,12 +20,14 @@ import platform
 import shutil
 import subprocess
 import sys
+import textwrap
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend as cryptography_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+
 from lxml import etree
 
 from rclpy.exceptions import InvalidNamespaceException
@@ -44,10 +46,10 @@ from sros2.policy import (
 HIDDEN_NODE_PREFIX = '_'
 DOMAIN_ID_ENV = 'ROS_DOMAIN_ID'
 
+DEFAULT_COMMON_NAME = 'sros2testCA'
+
 NodeName = namedtuple('NodeName', ('node', 'ns', 'fqn'))
 TopicInfo = namedtuple('Topic', ('fqn', 'type'))
-
-DEFAULT_COMMON_NAME = 'sros2testCA'
 
 
 def get_node_names(*, node, include_hidden_nodes=False):
@@ -145,64 +147,64 @@ def _write_cert(cert, cert_path, *, encoding=serialization.Encoding.PEM):
 
 
 def create_ca_conf_file(path):
-    conf_string = """\
-[ ca ]
-default_ca = CA_default
+    conf_string = textwrap.dedent("""\
+        [ ca ]
+        default_ca = CA_default
 
-[ CA_default ]
-dir = .
-certs = $dir/certs
-crl_dir = $dir/crl
-database = $dir/index.txt
-unique_subject = no
-new_certs_dir = $dir
-certificate = $dir/ca.cert.pem
-private_key = $dir/ca.key.pem
-serial = $dir/serial
-crlnumber = $dir/crlnumber
-crl = $dir/crl.pem
-RANDFILE = $dir/private/.rand
-name_opt = ca_default
-cert_opt = ca_default
-default_days = 1825
-default_crl_days = 30
-default_md = sha256
-preserve = no
-policy = policy_match
-x509_extensions = local_ca_extensions
-#
-#
-# Copy extensions specified in the certificate request
-#
-copy_extensions = copy
+        [ CA_default ]
+        dir = .
+        certs = $dir/certs
+        crl_dir = $dir/crl
+        database = $dir/index.txt
+        unique_subject = no
+        new_certs_dir = $dir
+        certificate = $dir/ca.cert.pem
+        private_key = $dir/ca.key.pem
+        serial = $dir/serial
+        crlnumber = $dir/crlnumber
+        crl = $dir/crl.pem
+        RANDFILE = $dir/private/.rand
+        name_opt = ca_default
+        cert_opt = ca_default
+        default_days = 1825
+        default_crl_days = 30
+        default_md = sha256
+        preserve = no
+        policy = policy_match
+        x509_extensions = local_ca_extensions
+        #
+        #
+        # Copy extensions specified in the certificate request
+        #
+        copy_extensions = copy
 
-[ policy_match ]
-countryName = optional
-stateOrProvinceName = optional
-organizationName = optional
-organizationalUnitName = optional
-commonName = supplied
-emailAddress = optional
+        [ policy_match ]
+        countryName = optional
+        stateOrProvinceName = optional
+        organizationName = optional
+        organizationalUnitName = optional
+        commonName = supplied
+        emailAddress = optional
 
-#
-#
-# x509 extensions to use when generating server certificates.
-#
-[ local_ca_extensions ]
-basicConstraints = CA:false
+        #
+        #
+        # x509 extensions to use when generating server certificates.
+        #
+        [ local_ca_extensions ]
+        basicConstraints = CA:false
 
-[ req ]
-prompt = no
-distinguished_name = req_distinguished_name
-string_mask = utf8only
-x509_extensions = root_ca_extensions
+        [ req ]
+        prompt = no
+        distinguished_name = req_distinguished_name
+        string_mask = utf8only
+        x509_extensions = root_ca_extensions
 
-[ req_distinguished_name ]
-commonName = {common_name}
+        [ req_distinguished_name ]
+        commonName = {common_name}
 
-[ root_ca_extensions ]
-basicConstraints = CA:true
-""".format(common_name=DEFAULT_COMMON_NAME)
+        [ root_ca_extensions ]
+        basicConstraints = CA:true
+        """.format(common_name=DEFAULT_COMMON_NAME))
     with open(path, 'w') as f:
         f.write(conf_string)
 

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -44,8 +44,8 @@ from sros2.policy import (
 HIDDEN_NODE_PREFIX = '_'
 DOMAIN_ID_ENV = 'ROS_DOMAIN_ID'
 
-NODE_NAME = namedtuple('NodeName', ('node', 'ns', 'fqn'))
-TOPIC_INFO = namedtuple('Topic', ('fqn', 'type'))
+NodeName = namedtuple('NodeName', ('node', 'ns', 'fqn'))
+TopicInfo = namedtuple('Topic', ('fqn', 'type'))
 
 DEFAULT_COMMON_NAME = 'sros2testCA'
 
@@ -53,7 +53,7 @@ DEFAULT_COMMON_NAME = 'sros2testCA'
 def get_node_names(*, node, include_hidden_nodes=False):
     node_names_and_namespaces = node.get_node_names_and_namespaces()
     return [
-        NODE_NAME(
+        NodeName(
             node=t[0],
             ns=t[1],
             fqn=t[1] + ('' if t[1].endswith('/') else '/') + t[0])
@@ -68,7 +68,7 @@ def get_node_names(*, node, include_hidden_nodes=False):
 def get_topics(node_name, func):
     names_and_types = func(node_name.node, node_name.ns)
     return [
-        TOPIC_INFO(
+        TopicInfo(
             fqn=t[0],
             type=t[1])
         for t in names_and_types]


### PR DESCRIPTION
Factors out the hardcoded `sros2testCA` into a constant `DEFAULT_COMMON_NAME`.

Once this is merged, the tests checking for the common name can be updated to leverage this new constant as well.

Long term, this should likely be exposed to users so that they can pick the name used instead of this hardcoded one