### PR TITLE
wip add governance template

### DIFF
--- a/sros2/sros2/policy/defaults/dds/governance.xml
+++ b/sros2/sros2/policy/defaults/dds/governance.xml
@@ -8,8 +8,8 @@
             </domains>
             <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
             <enable_join_access_control>true</enable_join_access_control>
-            <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
-            <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+            <discovery_protection_kind>SIGN</discovery_protection_kind>
+            <liveliness_protection_kind>SIGN</liveliness_protection_kind>
             <rtps_protection_kind>SIGN</rtps_protection_kind>
             <topic_access_rules>
                 <topic_rule>
@@ -18,7 +18,7 @@
                     <enable_liveliness_protection>true</enable_liveliness_protection>
                     <enable_read_access_control>true</enable_read_access_control>
                     <enable_write_access_control>true</enable_write_access_control>
-                    <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+                    <metadata_protection_kind>SIGN</metadata_protection_kind>
                     <data_protection_kind>ENCRYPT</data_protection_kind>
                 </topic_rule>
             </topic_access_rules>

--- a/sros2/sros2/policy/defaults/policy.xml
+++ b/sros2/sros2/policy/defaults/policy.xml
@@ -2,13 +2,13 @@
 <policy version="0.1.0">
   <profiles>
     <profile ns="/" node="default">
-      <topics publish="ALLOW" subscribe="ALLOW">
+      <topics publish="ALLOW" subscribe="ALLOW" protection="ENCRYPT">
         <topic>/*</topic>
       </topics>
-      <services reply="ALLOW" request="ALLOW">
+      <services reply="ALLOW" request="ALLOW" protection="ENCRYPT">
         <service>/*</service>
       </services>
-      <actions call="ALLOW" execute="ALLOW">
+      <actions call="ALLOW" execute="ALLOW" protection="ENCRYPT">
         <action>/*</action>
       </actions>
     </profile>

--- a/sros2/sros2/policy/schemas/policy.xsd
+++ b/sros2/sros2/policy/schemas/policy.xsd
@@ -40,6 +40,7 @@
         </xs:sequence>
         <xs:attribute name="publish" type="RuleQualifier" use="optional" />
         <xs:attribute name="subscribe" type="RuleQualifier" use="optional" />
+        <xs:attribute name="protection" type="ProtectionKind" use="required" />
         <xs:attribute ref="xml:base" />
     </xs:complexType>
 
@@ -49,6 +50,7 @@
         </xs:sequence>
         <xs:attribute name="reply" type="RuleQualifier" use="optional" />
         <xs:attribute name="request" type="RuleQualifier" use="optional" />
+        <xs:attribute name="protection" type="ProtectionKind" use="required" />
         <xs:attribute ref="xml:base" />
     </xs:complexType>
 
@@ -58,6 +60,7 @@
         </xs:sequence>
         <xs:attribute name="call" type="RuleQualifier" use="optional" />
         <xs:attribute name="execute" type="RuleQualifier" use="optional" />
+        <xs:attribute name="protection" type="ProtectionKind" use="required" />
         <xs:attribute ref="xml:base" />
     </xs:complexType>
 
@@ -69,6 +72,14 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="ALLOW" />
             <xs:enumeration value="DENY" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="ProtectionKind">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ENCRYPT" />
+            <xs:enumeration value="NONE" />
+            <xs:enumeration value="SIGN" />
         </xs:restriction>
     </xs:simpleType>
 

--- a/sros2/sros2/policy/templates/dds/governance.xsl
+++ b/sros2/sros2/policy/templates/dds/governance.xsl
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- TODO Sort resulting rules? -->
+<xsl:stylesheet version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+ xmlns:ext="http://exslt.org/common" exclude-result-prefixes="ext">
+ <xsl:output omit-xml-declaration="yes" indent="yes"/>
+ <xsl:strip-space elements="*"/>
+
+
+<xsl:variable name="template_domains">
+  <domains>
+    <id>0</id>
+  </domains>
+</xsl:variable>
+
+<xsl:template match="/policy/profiles">
+  <xsl:variable name="dds">
+    <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20170901/omg_shared_ca_governance.xsd">
+      <domain_access_rules>
+        <domain_rule>
+          <!-- FIXME what to do if multiple profiles? -->
+          <xsl:for-each select="profile">
+            <xsl:variable name="_ns">
+              <xsl:call-template name="DelimitNamespace">
+                <xsl:with-param name="ns" select="@ns"/>
+              </xsl:call-template>
+            </xsl:variable>
+            <xsl:copy-of select="$template_domains"/>
+            <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+            <enable_join_access_control>true</enable_join_access_control>
+            <discovery_protection_kind>SIGN</discovery_protection_kind>
+            <liveliness_protection_kind>SIGN</liveliness_protection_kind>
+            <rtps_protection_kind>SIGN</rtps_protection_kind>
+            <topic_access_rules>
+
+            <xsl:for-each select="./*[@* = 'ALLOW']">
+              <xsl:call-template name="TranslatePermissions">
+                <!--xsl:with-param name="qualifier" select="'ALLOW'"/-->
+              </xsl:call-template>
+            </xsl:for-each>
+            </topic_access_rules>
+          </xsl:for-each>
+        </domain_rule>
+      </domain_access_rules>
+    </dds>
+  </xsl:variable>
+
+ <xsl:apply-templates mode="sort"
+   select="ext:node-set($dds)"/>
+</xsl:template>
+
+<xsl:template name="TranslatePermissions">
+  <xsl:param name="qualifier"/>
+  <xsl:apply-templates select="."/>
+</xsl:template>
+
+<xsl:template name="EnableProtectionsDefault">
+  <enable_discovery_protection>true</enable_discovery_protection>
+  <enable_liveliness_protection>true</enable_liveliness_protection>
+  <enable_read_access_control>true</enable_read_access_control>
+  <enable_write_access_control>true</enable_write_access_control>
+</xsl:template>
+
+<xsl:template match="topics">
+  <xsl:for-each select="topic">
+  <xsl:variable name="fqn">
+    <xsl:apply-templates select="."/>
+  </xsl:variable>
+  <topic_rule>
+    <topic_expression>rt<xsl:value-of select="$fqn"/></topic_expression>
+    <xsl:call-template name="EnableProtectionsDefault"/>
+    <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+    <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+  </topic_rule>
+  </xsl:for-each>
+</xsl:template>
+
+<xsl:template match="services">
+  <xsl:for-each select="service">
+    <xsl:variable name="fqn">
+      <xsl:apply-templates select="."/>
+    </xsl:variable>
+    <topic_rule>
+      <topic_expression>rq<xsl:value-of select="$fqn"/>Request</topic_expression>
+      <xsl:call-template name="EnableProtectionsDefault"/>
+      <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+      <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+    </topic_rule>
+    <topic_rule>
+      <topic_expression>rr<xsl:value-of select="$fqn"/>Reply</topic_expression>
+      <xsl:call-template name="EnableProtectionsDefault"/>
+      <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+      <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+    </topic_rule>
+  </xsl:for-each>
+</xsl:template>
+
+<xsl:template match="actions">
+  <xsl:for-each select="action">
+    <xsl:variable name="fqn">
+      <xsl:apply-templates select="."/>
+    </xsl:variable>
+    <topic_rule>
+      <topic_expression>rq<xsl:value-of select="$fqn"/>/_action/cancel_goalRequest</topic_expression>
+      <xsl:call-template name="EnableProtectionsDefault"/>
+      <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+      <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+    </topic_rule>
+    <topic_rule>
+      <topic_expression>rr<xsl:value-of select="$fqn"/>/_action/cancel_goalReply</topic_expression>
+      <xsl:call-template name="EnableProtectionsDefault"/>
+      <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+      <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+    </topic_rule>
+    <topic_rule>
+      <topic_expression>rq<xsl:value-of select="$fqn"/>/_action/get_resultRequest</topic_expression>
+      <xsl:call-template name="EnableProtectionsDefault"/>
+      <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+      <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+    </topic_rule>
+    <topic_rule>
+      <topic_expression>rr<xsl:value-of select="$fqn"/>/_action/get_resultReply</topic_expression>
+      <xsl:call-template name="EnableProtectionsDefault"/>
+      <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+      <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+    </topic_rule>
+    <topic_rule>
+      <topic_expression>rq<xsl:value-of select="$fqn"/>/_action/send_goalRequest</topic_expression>
+      <xsl:call-template name="EnableProtectionsDefault"/>
+      <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+      <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+    </topic_rule>
+    <topic_rule>
+      <topic_expression>rr<xsl:value-of select="$fqn"/>/_action/send_goalReply</topic_expression>
+      <xsl:call-template name="EnableProtectionsDefault"/>
+      <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+      <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+    </topic_rule>
+    <topic_rule>
+      <topic_expression>rt<xsl:value-of select="$fqn"/>/_action/feedback</topic_expression>
+      <xsl:call-template name="EnableProtectionsDefault"/>
+      <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+      <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+    </topic_rule>
+    <topic_rule>
+      <topic_expression>rt<xsl:value-of select="$fqn"/>/_action/status</topic_expression>
+      <xsl:call-template name="EnableProtectionsDefault"/>
+      <metadata_protection_kind><xsl:value-of select="../@protection"/></metadata_protection_kind>
+      <data_protection_kind><xsl:value-of select="../@protection"/></data_protection_kind>
+    </topic_rule>
+  </xsl:for-each>
+</xsl:template>
+
+<xsl:template match="topic | service | action">
+  <xsl:variable name="ns" select="../../@ns"/>
+  <xsl:variable name="node" select="../../@node"/>
+  <xsl:variable name="name" select="."/>
+  <xsl:choose>
+    <xsl:when test="substring($name, 1, 1) = '/'">
+      <xsl:value-of select="$name"/>
+    </xsl:when>
+    <xsl:when test="substring($name, 1, 1) = '~'">
+      <xsl:variable name="_ns">
+        <xsl:call-template name="DelimitNamespace">
+          <xsl:with-param name="ns" select="$ns"/>
+        </xsl:call-template>
+      </xsl:variable>
+      <xsl:variable name="_name" select="substring($name, 2)"/>
+      <xsl:value-of select="concat($_ns, $node, '/', $_name)"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:variable name="_ns">
+        <xsl:call-template name="DelimitNamespace">
+          <xsl:with-param name="ns" select="$ns"/>
+        </xsl:call-template>
+      </xsl:variable>
+      <xsl:value-of select="concat($_ns, $name)"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template name="DelimitNamespace">
+  <xsl:param name="ns"/>
+  <xsl:choose>
+    <xsl:when test="substring($ns, string-length($ns), 1) = '/'">
+      <xsl:value-of select="$ns"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="concat($ns, '/')"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template match="@*|node()" mode="sort">
+  <xsl:copy>
+    <xsl:apply-templates select="@*|node()" mode="sort"/>
+  </xsl:copy>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/sros2/test/policies/add_two_ints.xml
+++ b/sros2/test/policies/add_two_ints.xml
@@ -5,14 +5,14 @@
     <profile ns="/" node="add_two_ints_server">
       <xi:include href="common/node.xml"
         xpointer="xpointer(/profile/*)"/>
-      <services reply="ALLOW">
+      <services reply="ALLOW" protection="ENCRYPT">
         <service>add_two_ints</service>
       </services>
     </profile>
     <profile ns="/" node="add_two_ints_client">
       <xi:include href="common/node.xml"
         xpointer="xpointer(/profile/*)"/>
-      <services request="ALLOW">
+      <services request="ALLOW" protection="ENCRYPT">
         <service>add_two_ints</service>
       </services>
     </profile>

--- a/sros2/test/policies/common/node/logging.xml
+++ b/sros2/test/policies/common/node/logging.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <profile>
-  <topics publish="ALLOW" >
+  <topics publish="ALLOW" protection="ENCRYPT">
     <topic>rosout</topic>
   </topics>
 </profile>

--- a/sros2/test/policies/common/node/parameters.xml
+++ b/sros2/test/policies/common/node/parameters.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <profile>
-  <topics publish="ALLOW" subscribe="ALLOW" >
+  <topics publish="ALLOW" subscribe="ALLOW" protection="ENCRYPT">
     <topic>parameter_events</topic>
   </topics>
 
-  <services reply="ALLOW" request="ALLOW" >
+  <services reply="ALLOW" request="ALLOW" protection="ENCRYPT">
     <service>~describe_parameters</service>
     <service>~get_parameter_types</service>
     <service>~get_parameters</service>

--- a/sros2/test/policies/common/node/time.xml
+++ b/sros2/test/policies/common/node/time.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <profile>
-  <topics subscribe="ALLOW" >
+  <topics subscribe="ALLOW" protection="ENCRYPT">
     <topic>/clock</topic>
   </topics>
 </profile>

--- a/sros2/test/policies/minimal_action.xml
+++ b/sros2/test/policies/minimal_action.xml
@@ -5,14 +5,14 @@
     <profile ns="/" node="minimal_action_server">
       <xi:include href="common/node.xml"
         xpointer="xpointer(/profile/*)"/>
-      <actions execute="ALLOW">
+      <actions execute="ALLOW" protection="ENCRYPT">
         <action>fibonacci</action>
       </actions>
     </profile>
     <profile ns="/" node="minimal_action_client">
       <xi:include href="common/node.xml"
         xpointer="xpointer(/profile/*)"/>
-      <actions call="ALLOW">
+      <actions call="ALLOW" protection="ENCRYPT">
         <action>fibonacci</action>
       </actions>
     </profile>

--- a/sros2/test/policies/sample_policy.xml
+++ b/sros2/test/policies/sample_policy.xml
@@ -11,13 +11,13 @@
     <profile ns="/" node="admin">
       <xi:include href="common/node.xml"
         xpointer="xpointer(/profile/*)"/>
-      <actions call="ALLOW" execute="ALLOW">
+      <actions call="ALLOW" execute="ALLOW" protection="ENCRYPT">
         <action>fibonacci</action>
       </actions>
-      <services reply="ALLOW" request="ALLOW">
+      <services reply="ALLOW" request="ALLOW" protection="ENCRYPT">
         <service>add_two_ints</service>
       </services>
-      <topics publish="ALLOW" subscribe="ALLOW">
+      <topics publish="ALLOW" subscribe="ALLOW" protection="SIGN">
         <topic>chatter</topic>
       </topics>
     </profile>

--- a/sros2/test/policies/talker_listener.xml
+++ b/sros2/test/policies/talker_listener.xml
@@ -5,14 +5,14 @@
     <profile ns="/" node="talker">
       <xi:include href="common/node.xml"
         xpointer="xpointer(/profile/*)"/>
-      <topics publish="ALLOW" >
+      <topics publish="ALLOW" protection="SIGN">
         <topic>chatter</topic>
       </topics>
     </profile>
     <profile ns="/" node="listener">
       <xi:include href="common/node.xml"
         xpointer="xpointer(/profile/*)"/>
-      <topics subscribe="ALLOW" >
+      <topics subscribe="ALLOW" protection="SIGN">
         <topic>chatter</topic>
       </topics>
     </profile>


### PR DESCRIPTION
Opening this for visibility, PoC for https://github.com/ros2/sros2/issues/130.
Will wait for the ongoing API changes to settle before deconflicting and iterating.

What's in this PR:
- New governance.xsl template to generate the governance files
- Modifies the policy format to take a new `protection` attribute
- change `create_signed_governance_file` argument order to match the ones from `create_signed_permission_file`
- removes creation of a keystore-wide governance file and generate one per key

Open ended questions:
- What is the best default behavior ? encrypting all data unless specified otherwise?
- Should the new attribute be required or optional ? (if optional use the default from previous bullet)

Still todo:
- cleanup code and refactor to avoid duplication
- settle on behavior in case of multiple policies to process 