### PR TITLE
remove now obsolete openssl dependency

### DIFF
--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -13,7 +13,6 @@
   <depend>rclpy</depend>
   <depend>ros2cli</depend>
 
-  <exec_depend>openssl</exec_depend>
   <exec_depend>python3-lxml</exec_depend>
   <exec_depend>python3-cryptography</exec_depend>
 


### PR DESCRIPTION
Now that https://github.com/ros2/sros2/issues/109 has been addressed there is no need for an explicit dependency on the openssl executable. `python3-cryptography` should bring in the necessary OpenSSL libraries.