### PR TITLE
[WIP] policy: add class representation of XML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .eggs/
 .coverage
+.mypy_cache/

--- a/sros2/sros2/__init__.py
+++ b/sros2/sros2/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class SROS2Error(Exception):
+    """Base class for all SROS 2 exceptions."""
+
+    def __init__(self, message=''):
+        self.message = message
+
+    def __str__(self):
+        message = str(self.message)
+        if not message and self.__doc__:
+            message = self.__doc__
+
+        return message

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -33,6 +33,7 @@ from sros2.policy import (
     get_transport_schema,
     get_transport_template,
     load_policy,
+    POLICY_VERSION,
 )
 
 HIDDEN_NODE_PREFIX = '_'
@@ -551,3 +552,55 @@ def generate_artifacts(keystore_path=None, identity_names=[], policy_files=[]):
             create_permissions_from_policy_element(
                 keystore_path, identity_name, policy_element)
     return True
+
+
+class PolicyBuilder(object):
+    """Load and modify an XML security policy."""
+    def __init__(self, policy_file_path):
+        if os.path.isfile(policy_file_path):
+            self.policy = load_policy(policy_file_path)
+        else:
+            profiles = etree.Element('profiles')
+            self.policy = etree.Element('policy')
+            self.policy.attrib['version'] = POLICY_VERSION
+            self.policy.append(profiles)
+
+    def get_profile(self, node_name):
+        profile = self.policy.find(
+            path='profiles/profile[@ns="{ns}"][@node="{node}"]'.format(
+                ns=node_name.ns,
+                node=node_name.node))
+        if profile is None:
+            profile = etree.Element('profile')
+            profile.attrib['ns'] = node_name.ns
+            profile.attrib['node'] = node_name.node
+            profiles = self.policy.find('profiles')
+            profiles.append(profile)
+        return profile
+
+    def get_permissions(self, profile, permission_type, rule_type, rule_qualifier):
+        permissions = profile.find(
+            path='{permission_type}s[@{rule_type}="{rule_qualifier}"]'.format(
+                permission_type=permission_type,
+                rule_type=rule_type,
+                rule_qualifier=rule_qualifier))
+        if permissions is None:
+            permissions = etree.Element(permission_type + 's')
+            permissions.attrib[rule_type] = rule_qualifier
+            profile.append(permissions)
+        return permissions
+
+    def add_permission(
+            self, profile, permission_type, rule_type, rule_qualifier, expressions, node_name):
+        permissions = self.get_permissions(profile, permission_type, rule_type, rule_qualifier)
+        for expression in expressions:
+            permission = etree.Element(permission_type)
+            if expression.fqn.startswith(node_name.fqn + '/'):
+                permission.text = '~' + expression.fqn[len(node_name.fqn + '/'):]
+            elif expression.fqn.startswith(node_name.ns + '/'):
+                permission.text = expression.fqn[len(node_name.ns + '/'):]
+            elif expression.fqn.count('/') == 1 and node_name.ns == '/':
+                permission.text = expression.fqn[len('/'):]
+            else:
+                permission.text = expression.fqn
+            permissions.append(permission)

--- a/sros2/sros2/policy/_expression.py
+++ b/sros2/sros2/policy/_expression.py
@@ -1,0 +1,91 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import enum
+
+from lxml import etree
+
+from . import PolicyError
+
+
+class UnsupportedExpressionTypeError(PolicyError):
+
+    def __init__(self, type_string: str):
+        super().__init__('Unsupported expression type: {!r}'.format(type_string))
+        self.type = type_string
+
+
+@enum.unique
+class ExpressionType(enum.Enum):
+    # Enum values should map to their XML values
+    TOPIC = 'topic'
+    SERVICE = 'service'
+
+
+class Expression:
+    """Class representation of an expression within a permission of an XML security policy."""
+
+    @classmethod
+    def from_fields(
+            cls, fqn: str, namespace: str, expression_type: ExpressionType,
+            text: str) -> 'Expression':
+        """
+        Create new Expression instance from its fields.
+
+        :param str fqn: The node FQN.
+        :param str namespace: The node namespace.
+        :param ExpressionType expression_type: Type of expression.
+        :param str text: Text of expression.
+
+        :returns: The newly-created expression.
+        :rtype: Expression
+        """
+        expression = etree.Element(expression_type.value)
+        namespace = namespace.rstrip('/')
+
+        if text.startswith(fqn + '/'):
+            text = '~' + text[len(fqn + '/'):]
+        elif text.startswith(namespace + '/'):
+            text = text[len(namespace + '/'):]
+
+        expression.text = text
+
+        return cls(expression)
+
+    def __init__(self, expression: etree.Element) -> None:
+        """
+        Create new Expression instance.
+
+        :param etree.Element expression: XML Element containing the expression.
+        """
+        self._expression = expression
+
+    def get_type(self) -> ExpressionType:
+        """
+        Return the type of the expression.
+
+        :rtype: ExpressionType
+        """
+        try:
+            return ExpressionType(self._expression.tag)
+        except ValueError as e:
+            raise UnsupportedExpressionTypeError(self._expression.tag) from e
+
+    def get_text(self) -> str:
+        """
+        Return the text of the expression.
+
+        :rtype: str
+        """
+        return self._expression.text

--- a/sros2/sros2/policy/_expression.py
+++ b/sros2/sros2/policy/_expression.py
@@ -31,6 +31,7 @@ class ExpressionType(enum.Enum):
     # Enum values should map to their XML values
     TOPIC = 'topic'
     SERVICE = 'service'
+    ACTION = 'action'
 
 
 class Expression:

--- a/sros2/sros2/policy/_permission.py
+++ b/sros2/sros2/policy/_permission.py
@@ -1,0 +1,136 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import enum
+from typing import List
+
+from lxml import etree
+
+from . import PolicyError
+from ._expression import Expression
+
+
+class UnsupportedPolicyError(PolicyError):
+    """Not necessarily an invalid policy, but one this class doesn't support."""
+
+    def __init__(self, why):
+        super().__init__('Unsupported SROS 2 policy: {}'.format(why))
+
+
+@enum.unique
+class PermissionType(enum.Enum):
+    # Enum values should map to their XML values
+    TOPIC = 'topics'
+    SERVICE = 'services'
+
+
+@enum.unique
+class PermissionRuleType(enum.Enum):
+    # Enum values should map to their XML values
+    SUBSCRIBE = 'subscribe'
+    PUBLISH = 'publish'
+    REPLY = 'reply'
+
+
+@enum.unique
+class PermissionRuleQualifier(enum.Enum):
+    # Enum values should map to their XML values
+    ALLOW = 'ALLOW'
+
+
+class Permission:
+    """Class representation of a profile's permission within an XML security policy."""
+
+    @classmethod
+    def from_fields(
+            cls, permission_type: PermissionType, rule_type: PermissionRuleType,
+            rule_qualifier: PermissionRuleQualifier) -> 'Permission':
+        """
+        Create new Permission instance from its fields.
+
+        :param PermissionType permission_type: The type of permission.
+        :param PermissionRuleType rule_type: The type of rule.
+        :param PermissionRuleQualifier rule_qualifier: Qualifier for the rule.
+
+        :returns: The newly-created permission.
+        :rtype: Permission
+        """
+        permission = etree.Element(permission_type.value)
+        permission.attrib[rule_type.value] = rule_qualifier.value
+
+        return cls(permission)
+
+    def __init__(self, permission: etree.Element) -> None:
+        """
+        Create new Permission instance.
+
+        :param etree.Element profile: XML Element containing the permission.
+        """
+        self._permission = permission
+
+    def get_type(self) -> PermissionType:
+        """
+        Return the type of the permission.
+
+        :rtype: PermissionType
+        """
+        return PermissionType(self._permission.tag)
+
+    def get_rule_type(self) -> PermissionRuleType:
+        """
+        Return the type of the rule.
+
+        :rtype: PermissionRuleType
+        """
+        keys = self._permission.keys()
+        if len(keys) != 1:
+            raise UnsupportedPolicyError(
+                'Expected a single attribute to determine rule type, got {!r}'.format(keys))
+
+        return PermissionRuleType(keys[0])
+
+    def get_rule_qualifier(self) -> PermissionRuleQualifier:
+        """
+        Return the qualifier of the rule.
+
+        :rtype: PermissionRuleQualifier
+        """
+        return PermissionRuleQualifier(self._permission.get(self.get_rule_type().value))
+
+    def get_expressions(self) -> List[Expression]:
+        """
+        Return all expressions making up the permission.
+
+        :rtype: list
+        """
+        expressions = []
+        for child in self._permission:
+            expressions.append(Expression(child))
+
+        return expressions
+
+    def add_expression(self, expression: Expression) -> Expression:
+        """
+        Add expression to the permission.
+
+        :param Expression expression: Expression to be added.
+
+        :returns: The expression that was added
+        :rtype: Expression
+
+        Future modifications of the expression will be reflected in this permission once this
+        function is called.
+        """
+        self._permission.append(expression._expression)
+        return expression

--- a/sros2/sros2/policy/_permission.py
+++ b/sros2/sros2/policy/_permission.py
@@ -33,6 +33,7 @@ class PermissionType(enum.Enum):
     # Enum values should map to their XML values
     TOPIC = 'topics'
     SERVICE = 'services'
+    ACTION = 'actions'
 
 
 @enum.unique
@@ -42,12 +43,15 @@ class PermissionRuleType(enum.Enum):
     PUBLISH = 'publish'
     REPLY = 'reply'
     REQUEST = 'request'
+    CALL = 'call'
+    EXECUTE = 'execute'
 
 
 @enum.unique
 class PermissionRuleQualifier(enum.Enum):
     # Enum values should map to their XML values
     ALLOW = 'ALLOW'
+    DENY = 'DENY'
 
 
 class Permission:

--- a/sros2/sros2/policy/_policy.py
+++ b/sros2/sros2/policy/_policy.py
@@ -1,0 +1,108 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import List, Optional, TextIO, Union
+
+from lxml import etree
+
+from . import dump_policy, load_policy, POLICY_VERSION
+from ._profile import Profile
+
+
+class Policy:
+    """Class representation of an XML security policy."""
+
+    def __init__(self, *, source: Union[TextIO, str] = None) -> None:
+        """
+        Create new Policy instance, optionally by loading an existing policy.
+
+        :param source: Either the path to existing policy file to be loaded, or file-like
+                       object containing existing policy.
+        """
+        # If source was provided, initialize this class with it. Otherwise, start a fresh
+        # (empty) one.
+        if source and (not isinstance(source, str) or os.path.isfile(source)):
+            self._policy = load_policy(source).getroot()
+        else:
+            profiles = etree.Element('profiles')
+            self._policy = etree.Element('policy')
+            self._policy.attrib['version'] = POLICY_VERSION
+            self._policy.append(profiles)
+
+    def get_version(self) -> str:
+        """
+        Return the version of the policy.
+
+        :rtype: str
+        """
+        return self._policy.get('version')
+
+    def get_profiles(self) -> List[Profile]:
+        """
+        Return all profiles making up the policy.
+
+        :rtype: list
+        """
+        profiles = []
+        for child in self._policy.find('profiles'):
+            profiles.append(Profile(child))
+
+        return profiles
+
+    def get_profile(self, node_name: str, namespace: str) -> Optional[Profile]:
+        """
+        Get profile that matches provided parameters.
+
+        :param str node_name: The name of the profile's node
+        :param str namespace: The namespace of the profile's node.
+
+        If no matching profile exists, this function will return None.
+        """
+        xml_profile = self._policy.find(
+            path='profiles/profile[@ns="{ns}"][@node="{node}"]'.format(
+                ns=namespace,
+                node=node_name))
+
+        if xml_profile is not None:
+            return Profile(xml_profile)
+        else:
+            return None
+
+    def add_profile(self, profile: Profile) -> Profile:
+        self._policy.find('profiles').append(profile._profile)
+        return profile
+
+    def get_or_create_profile(self, node_name: str, namespace: str) -> Profile:
+        """
+        Get matching profile or create new one if it doesn't exist.
+
+        :param str node_name: The name of the profile's node
+        :param str namespace: The namespace of the profile's node.
+
+        Future modifications of the profile will be reflected in this policy once this
+        function is called.
+        """
+        profile = self.get_profile(node_name, namespace)
+        if not profile:
+            profile = self.add_profile(Profile.from_fields(node_name, namespace))
+        return profile
+
+    def dump(self, stream: TextIO):
+        """
+        Dump policy to stream.
+
+        :param TextIO stream: File like object to which policy will be written.
+        """
+        dump_policy(self._policy, stream)

--- a/sros2/sros2/policy/_profile.py
+++ b/sros2/sros2/policy/_profile.py
@@ -1,0 +1,133 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional
+
+from lxml import etree
+
+from ._permission import Permission, PermissionRuleQualifier, PermissionRuleType, PermissionType
+
+
+class Profile:
+    """Class representation of a profile within an XML security policy."""
+
+    @classmethod
+    def from_fields(cls, node_name: str, namespace: str) -> 'Profile':
+        """
+        Create new Profile instance from its fields.
+
+        :param str node_name: The name of the profile's node
+        :param str namespace: The namespace of the profile's node.
+
+        :returns: The newly-created profile.
+        :rtype: Profile
+        """
+        profile = etree.Element('profile')
+        profile.attrib['ns'] = namespace
+        profile.attrib['node'] = node_name
+
+        return cls(profile)
+
+    def __init__(self, profile: etree.Element) -> None:
+        """
+        Create new Profile instance.
+
+        :param etree.Element profile: XML Element containing the profile.
+        """
+        self._profile = profile
+
+    def get_node(self) -> str:
+        """
+        Return the name of the profile's node.
+
+        :rtype: str
+        """
+        return self._profile.get('node')
+
+    def get_namespace(self) -> str:
+        """
+        Return the namespace of the profile's node.
+
+        :rtype: str
+        """
+        return self._profile.get('ns')
+
+    def get_permissions(self) -> List[Permission]:
+        """
+        Return all permissions making up the profile.
+
+        :rtype: list
+        """
+        permissions = []
+        for child in self._profile:
+            permissions.append(Permission(child))
+
+        return permissions
+
+    def get_permission(
+            self, permission_type: PermissionType, rule_type: PermissionRuleType,
+            rule_qualifier: PermissionRuleQualifier) -> Optional[Permission]:
+        """
+        Get permission that matches provided parameters.
+
+        :param PermissionType permission_type: The type of permission.
+        :param PermissionRuleType rule_type: The type of rule.
+        :param PermissionRuleQualifier rule_qualifier: Qualifier for the rule.
+
+        If no matching permission exists, this function will return None.
+        """
+        permission_xml = self._profile.find(
+            path='{permission_type}[@{rule_type}="{rule_qualifier}"]'.format(
+                permission_type=permission_type.value,
+                rule_type=rule_type.value,
+                rule_qualifier=rule_qualifier.value))
+
+        if permission_xml is not None:
+            return Permission(permission_xml)
+        else:
+            return None
+
+    def add_permission(self, permission: Permission) -> Permission:
+        """
+        Add permission to the profile.
+
+        :param Permission permission: Permission to be added.
+
+        :returns: The permission that was added
+        :rtype: Permission
+
+        Future modifications of the permission will be reflected in this profile once this
+        function is called.
+        """
+        self._profile.append(permission._permission)
+        return permission
+
+    def get_or_create_permission(
+            self, permission_type: PermissionType, rule_type: PermissionRuleType,
+            rule_qualifier: PermissionRuleQualifier) -> Permission:
+        """
+        Get matching permission or create new one if it doesn't exist.
+
+        :param PermissionType permission_type: The type of permission.
+        :param PermissionRuleType rule_type: The type of rule.
+        :param PermissionRuleQualifier rule_qualifier: Qualifier for the rule.
+
+        Future modifications of the permission will be reflected in this profile once this
+        function is called.
+        """
+        permission = self.get_permission(permission_type, rule_type, rule_qualifier)
+        if not permission:
+            permission = self.add_permission(
+                Permission.from_fields(permission_type, rule_type, rule_qualifier))
+        return permission

--- a/sros2/test/sros2/commands/security/verbs/test_generate_policy.py
+++ b/sros2/test/sros2/commands/security/verbs/test_generate_policy.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+import textwrap
 
 import pytest
 
@@ -33,7 +34,9 @@ def test_generate_policy():
         try:
             # Create a publisher and subscription
             node.create_publisher(String, 'topic_pub', 1)
-            node.create_subscription(String, 'topic_sub', lambda msg: None, 1)
+            node.create_subscription(String, '/topic_sub', lambda msg: None, 1)
+            node.create_publisher(String, 'topic/both', 1)
+            node.create_subscription(String, 'topic/both', lambda msg: None, 1)
 
             # Generate the policy for the running node
             assert cli.main(
@@ -51,12 +54,76 @@ def test_generate_policy():
         topics_subscribe_allowed = profile.find(path='topics[@subscribe="ALLOW"]')
         assert topics_subscribe_allowed is not None
 
-        # Verify that the allowed publications include topic_pub and not topic_sub
+        # Verify that the allowed publications include topic_pub and topic_both, but not
+        # topic_sub
+        topics = topics_publish_allowed.findall('topic')
+        assert len([t for t in topics if t.text == 'topic_pub']) == 1
+        assert len([t for t in topics if t.text == 'topic/both']) == 1
+        assert len([t for t in topics if t.text == 'topic_sub']) == 0
+
+        # Verify that the allowed subscriptions include topic_sub and topic_both, but not
+        # topic_pub
+        topics = topics_subscribe_allowed.findall('topic')
+        assert len([t for t in topics if t.text == 'topic_sub']) == 1
+        assert len([t for t in topics if t.text == 'topic/both']) == 1
+        assert len([t for t in topics if t.text == 'topic_pub']) == 0
+
+        # Couple last sanity checks to ensure various expression formats are supported
+        services_reply_allowed = profile.find(path='services[@reply="ALLOW"]')
+        assert services_reply_allowed is not None
+
+        services = services_reply_allowed.findall('service')
+        assert len([s for s in services if s.text == '~describe_parameters']) == 1
+
+
+def test_generate_policy_append():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a test-specific context so that generate_policy can still init
+        context = rclpy.Context()
+        rclpy.init(context=context)
+        node = rclpy.create_node('test_node', context=context)
+
+        # Create an initial policy
+        with open(os.path.join(tmpdir, 'test-policy.xml'), 'w') as f:
+            f.write(textwrap.dedent("""\
+                <?xml version="1.0" encoding="UTF-8"?>
+                <policy version="0.1.0">
+                    <profiles>
+                        <profile ns="/" node="test_node">
+                            <topics publish="ALLOW" >
+                                <topic>topic_pub</topic>
+                            </topics>
+                        </profile>
+                    </profiles>
+                </policy>
+            """))
+
+        try:
+            # Create a subscription
+            node.create_subscription(String, '/topic_sub', lambda msg: None, 1)
+
+            # Generate the policy for the running node, based on the existing policy
+            assert cli.main(
+                argv=['security', 'generate_policy', os.path.join(tmpdir, 'test-policy.xml')]) == 0
+        finally:
+            node.destroy_node()
+            rclpy.shutdown(context=context)
+
+        # Load the policy and pull out the allowed publications and subscriptions
+        policy = load_policy(os.path.join(tmpdir, 'test-policy.xml'))
+        profile = policy.find(path='profiles/profile[@ns="/"][@node="test_node"]')
+        assert profile is not None
+        topics_publish_allowed = profile.find(path='topics[@publish="ALLOW"]')
+        assert topics_publish_allowed is not None
+        topics_subscribe_allowed = profile.find(path='topics[@subscribe="ALLOW"]')
+        assert topics_subscribe_allowed is not None
+
+        # Verify that the allowed publications include topic_pub, but not topic_sub
         topics = topics_publish_allowed.findall('topic')
         assert len([t for t in topics if t.text == 'topic_pub']) == 1
         assert len([t for t in topics if t.text == 'topic_sub']) == 0
 
-        # Verify that the allowed subscriptions include topic_sub and not topic_pub
+        # Verify that the allowed subscriptions include topic_sub, but not topic_pub
         topics = topics_subscribe_allowed.findall('topic')
         assert len([t for t in topics if t.text == 'topic_sub']) == 1
         assert len([t for t in topics if t.text == 'topic_pub']) == 0

--- a/sros2/test/sros2/policy/test_expression.py
+++ b/sros2/test/sros2/policy/test_expression.py
@@ -1,0 +1,100 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from lxml import etree
+
+import pytest
+
+from sros2.policy import _expression
+
+
+def test_topic_from_xml():
+    expression_xml = etree.fromstring(textwrap.dedent("""\
+        <topic>test_topic</topic>
+    """))
+
+    _assert_topic(_expression.Expression(expression_xml))
+
+
+def test_service_from_xml():
+    expression_xml = etree.fromstring(textwrap.dedent("""\
+        <service>test_service</service>
+    """))
+
+    _assert_service(_expression.Expression(expression_xml))
+
+
+def test_unsupported_type_from_xml():
+    expression_xml = etree.fromstring(textwrap.dedent("""\
+        <unsupported>test</unsupported>
+    """))
+
+    expression = _expression.Expression(expression_xml)
+
+    with pytest.raises(_expression.UnsupportedExpressionTypeError) as e:
+        expression.get_type()
+    assert e.value.type == 'unsupported'
+
+
+def test_topic_from_fields():
+    _assert_topic(_expression.Expression.from_fields(
+        '/test_node', '/', _expression.ExpressionType.TOPIC, 'test_topic'))
+
+
+def test_service_from_fields():
+    _assert_service(_expression.Expression.from_fields(
+        '/test_node', '/', _expression.ExpressionType.SERVICE, 'test_service'))
+
+
+def test_nested_under_node():
+    expression = _expression.Expression.from_fields(
+        '/test_node', '/', _expression.ExpressionType.TOPIC, '/test_node/test_topic')
+    assert expression.get_type() == _expression.ExpressionType.TOPIC
+    assert expression.get_text() == '~test_topic'
+
+    expression = _expression.Expression.from_fields(
+        '/test_node', '/', _expression.ExpressionType.TOPIC, '/test_node/level2/test_topic')
+    assert expression.get_type() == _expression.ExpressionType.TOPIC
+    assert expression.get_text() == '~level2/test_topic'
+
+
+def test_nested_under_namespace():
+    expression = _expression.Expression.from_fields(
+        '/test_node', '/ns', _expression.ExpressionType.TOPIC, '/ns/test_topic')
+    assert expression.get_type() == _expression.ExpressionType.TOPIC
+    assert expression.get_text() == 'test_topic'
+
+    # The special case of namespace being '/' should be properly handled: topics within the
+    # namespace should still be relative in the profile.
+    expression = _expression.Expression.from_fields(
+        '/test_node', '/', _expression.ExpressionType.TOPIC, '/another_ns/test_topic')
+    assert expression.get_type() == _expression.ExpressionType.TOPIC
+    assert expression.get_text() == 'another_ns/test_topic'
+
+    expression = _expression.Expression.from_fields(
+        '/test_node', '/', _expression.ExpressionType.TOPIC, '/test_topic')
+    assert expression.get_type() == _expression.ExpressionType.TOPIC
+    assert expression.get_text() == 'test_topic'
+
+
+def _assert_topic(expression):
+    assert expression.get_type() == _expression.ExpressionType.TOPIC
+    assert expression.get_text() == 'test_topic'
+
+
+def _assert_service(expression):
+    assert expression.get_type() == _expression.ExpressionType.SERVICE
+    assert expression.get_text() == 'test_service'

--- a/sros2/test/sros2/policy/test_permission.py
+++ b/sros2/test/sros2/policy/test_permission.py
@@ -1,0 +1,139 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from lxml import etree
+
+import pytest
+
+from sros2.policy import _expression, _permission
+
+
+def test_topic_publish_allow_from_xml():
+    permission_xml = etree.fromstring(textwrap.dedent("""\
+        <topics publish="ALLOW">
+            <topic>test_topic</topic>
+        </topics>
+    """))
+
+    permission = _permission.Permission(permission_xml)
+    _assert_topic_publish(permission)
+    _assert_topic_expressions(permission)
+
+
+def test_topic_subscribe_allow_from_xml():
+    permission_xml = etree.fromstring(textwrap.dedent("""\
+        <topics subscribe="ALLOW">
+            <topic>test_topic</topic>
+        </topics>
+    """))
+
+    permission = _permission.Permission(permission_xml)
+    _assert_topic_subscribe(permission)
+    _assert_topic_expressions(permission)
+
+
+def test_service_reply_allow_from_xml():
+    permission_xml = etree.fromstring(textwrap.dedent("""\
+        <services reply="ALLOW">
+            <service>test_service</service>
+        </services>
+    """))
+
+    permission = _permission.Permission(permission_xml)
+    _assert_service_reply(permission)
+    _assert_service_expressions(permission)
+
+
+def test_topic_publish_allow_from_fields():
+    _assert_topic_publish(_permission.Permission.from_fields(
+        _permission.PermissionType.TOPIC, _permission.PermissionRuleType.PUBLISH,
+        _permission.PermissionRuleQualifier.ALLOW))
+
+
+def test_topic_subscribe_allow_from_fields():
+    _assert_topic_subscribe(_permission.Permission.from_fields(
+        _permission.PermissionType.TOPIC, _permission.PermissionRuleType.SUBSCRIBE,
+        _permission.PermissionRuleQualifier.ALLOW))
+
+
+def test_service_reply_allow_from_fields():
+    _assert_service_reply(_permission.Permission.from_fields(
+        _permission.PermissionType.SERVICE, _permission.PermissionRuleType.REPLY,
+        _permission.PermissionRuleQualifier.ALLOW))
+
+
+def test_unsupported_permission():
+    permission_xml = etree.fromstring(textwrap.dedent("""\
+        <topics publish="ALLOW" subscribe="ALLOW">
+            <topic>test_topic</topic>
+        </topics>
+    """))
+
+    permission = _permission.Permission(permission_xml)
+
+    with pytest.raises(_permission.UnsupportedPolicyError):
+        permission.get_rule_type()
+
+
+def test_add_expression():
+    permission_xml = etree.fromstring(textwrap.dedent("""\
+        <topics publish="ALLOW">
+        </topics>
+    """))
+
+    permission = _permission.Permission(permission_xml)
+    assert len(permission.get_expressions()) == 0
+
+    permission.add_expression(_expression.Expression.from_fields(
+        '/test_node', '/', _expression.ExpressionType.TOPIC, 'test_topic'))
+
+    _assert_topic_publish(permission)
+
+
+def _assert_topic_publish(permission):
+    assert permission.get_type() == _permission.PermissionType.TOPIC
+    assert permission.get_rule_type() == _permission.PermissionRuleType.PUBLISH
+    assert permission.get_rule_qualifier() == _permission.PermissionRuleQualifier.ALLOW
+
+
+def _assert_topic_subscribe(permission):
+    assert permission.get_type() == _permission.PermissionType.TOPIC
+    assert permission.get_rule_type() == _permission.PermissionRuleType.SUBSCRIBE
+    assert permission.get_rule_qualifier() == _permission.PermissionRuleQualifier.ALLOW
+
+
+def _assert_topic_expressions(permission):
+    expressions = permission.get_expressions()
+    assert len(expressions) == 1
+
+    expression = expressions[0]
+    assert expression.get_type() == _expression.ExpressionType.TOPIC
+    assert expression.get_text() == 'test_topic'
+
+
+def _assert_service_reply(permission):
+    assert permission.get_type() == _permission.PermissionType.SERVICE
+    assert permission.get_rule_type() == _permission.PermissionRuleType.REPLY
+    assert permission.get_rule_qualifier() == _permission.PermissionRuleQualifier.ALLOW
+
+
+def _assert_service_expressions(permission):
+    expressions = permission.get_expressions()
+    assert len(expressions) == 1
+
+    expression = expressions[0]
+    assert expression.get_type() == _expression.ExpressionType.SERVICE
+    assert expression.get_text() == 'test_service'

--- a/sros2/test/sros2/policy/test_policy.py
+++ b/sros2/test/sros2/policy/test_policy.py
@@ -1,0 +1,106 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import textwrap
+
+import pytest
+
+from sros2.policy import _expression, _permission, _policy, _profile, InvalidPolicyError
+
+
+def test_policy():
+    contents = textwrap.dedent("""\
+        <policy version="0.1.0">
+            <profiles>
+                <profile ns="/ns" node="test_node">
+                    <topics publish="ALLOW">
+                        <topic>pub_topic</topic>
+                    </topics>
+                </profile>
+            </profiles>
+        </policy>
+    """)
+
+    with io.StringIO(contents) as s:
+        policy = _policy.Policy(source=s)
+
+    assert policy.get_version() == '0.1.0'
+
+    assert len(policy.get_profiles()) == 1
+    profile = policy.get_profile('test_node', '/ns')
+    assert profile is not None
+
+
+def test_get_profile_not_found():
+    contents = textwrap.dedent("""\
+        <policy version="0.1.0">
+            <profiles>
+                <profile ns="/ns" node="test_node">
+                    <topics publish="ALLOW">
+                        <topic>pub_topic</topic>
+                    </topics>
+                </profile>
+            </profiles>
+        </policy>
+    """)
+
+    with io.StringIO(contents) as s:
+        policy = _policy.Policy(source=s)
+
+    profile = policy.get_profile('another_node', '/ns')
+    assert profile is None
+
+
+def test_dump_invalid_policy():
+    policy = _policy.Policy()
+    with io.StringIO() as s:
+        with pytest.raises(InvalidPolicyError):
+            policy.dump(s)
+
+
+def test_add_profile():
+    policy = _policy.Policy()
+    assert len(policy.get_profiles()) == 0
+
+    profile = _profile.Profile.from_fields('test_node', '/ns')
+    policy.add_profile(profile)
+    assert len(profile.get_permissions()) == 0
+
+    permission = _permission.Permission.from_fields(
+        _permission.PermissionType.TOPIC, _permission.PermissionRuleType.PUBLISH,
+        _permission.PermissionRuleQualifier.ALLOW)
+    assert len(permission.get_expressions()) == 0
+
+    expression = _expression.Expression.from_fields(
+        '/test_node', '/ns', _expression.ExpressionType.TOPIC, 'test_topic')
+
+    permission.add_expression(expression)
+    profile.add_permission(permission)
+
+    # Verify that the above modification is reflected in the profile
+    profile = policy.get_profile('test_node', '/ns')
+    assert profile is not None
+
+    permission = profile.get_permission(
+        _permission.PermissionType.TOPIC, _permission.PermissionRuleType.PUBLISH,
+        _permission.PermissionRuleQualifier.ALLOW)
+    assert permission is not None
+
+    expressions = permission.get_expressions()
+    assert len(expressions) == 1
+
+    expression = expressions[0]
+    assert expression.get_type() == _expression.ExpressionType.TOPIC
+    assert expression.get_text() == 'test_topic'

--- a/sros2/test/sros2/policy/test_profile.py
+++ b/sros2/test/sros2/policy/test_profile.py
@@ -1,0 +1,94 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from lxml import etree
+
+from sros2.policy import _expression, _permission, _profile
+
+
+def test_get_permission():
+    profile_xml = etree.fromstring(textwrap.dedent("""\
+        <profile ns="/" node="test_node">
+            <topics publish="ALLOW">
+                <topic>test_topic</topic>
+            </topics>
+        </profile>
+    """))
+
+    profile = _profile.Profile(profile_xml)
+    assert profile.get_node() == 'test_node'
+    assert profile.get_namespace() == '/'
+
+    assert len(profile.get_permissions()) == 1
+    permission = profile.get_permission(
+        _permission.PermissionType.TOPIC, _permission.PermissionRuleType.PUBLISH,
+        _permission.PermissionRuleQualifier.ALLOW)
+    assert permission is not None
+
+
+def test_from_fields():
+    profile = _profile.Profile.from_fields('test_node', '/')
+    assert profile.get_node() == 'test_node'
+    assert profile.get_namespace() == '/'
+    assert len(profile.get_permissions()) == 0
+
+
+def test_get_permission_not_found():
+    profile_xml = etree.fromstring(textwrap.dedent("""\
+        <profile ns="/" node="test_node">
+            <topics publish="ALLOW">
+                <topic>test_topic</topic>
+            </topics>
+        </profile>
+    """))
+
+    profile = _profile.Profile(profile_xml)
+    permission = profile.get_permission(
+        _permission.PermissionType.TOPIC, _permission.PermissionRuleType.SUBSCRIBE,
+        _permission.PermissionRuleQualifier.ALLOW)
+    assert permission is None
+
+
+def test_add_permission():
+    profile_xml = etree.fromstring(textwrap.dedent("""\
+        <profile ns="/" node="test_node">
+        </profile>
+    """))
+
+    profile = _profile.Profile(profile_xml)
+    assert len(profile.get_permissions()) == 0
+
+    permission = _permission.Permission.from_fields(
+        _permission.PermissionType.TOPIC, _permission.PermissionRuleType.PUBLISH,
+        _permission.PermissionRuleQualifier.ALLOW)
+    profile.add_permission(permission)
+
+    assert len(permission.get_expressions()) == 0
+    permission.add_expression(_expression.Expression.from_fields(
+        '/test_node', '/', _expression.ExpressionType.TOPIC, 'test_topic'))
+
+    # Verify that the above modification is reflected in the profile
+    permission = profile.get_permission(
+        _permission.PermissionType.TOPIC, _permission.PermissionRuleType.PUBLISH,
+        _permission.PermissionRuleQualifier.ALLOW)
+    assert permission is not None
+
+    expressions = permission.get_expressions()
+    assert len(expressions) == 1
+
+    expression = expressions[0]
+    assert expression.get_type() == _expression.ExpressionType.TOPIC
+    assert expression.get_text() == 'test_topic'


### PR DESCRIPTION
XML is not the easiest thing to parse (or create). However, SROS 2  policies are nicely grouped into objects that lend themselves well to a class representation. This PR adds a set of user-friendly classes that represents an SROS 2 policy and its components that can load and dump themselves from and to XML. It also replaces important strings with enums such that they cannot be mistaken. It then updates `generate_policy` to use this new  system. Finally, it covers the whole thing in tests, which is the primary source of the line count (my apologies)