### PR TITLE
tests: use older pytest

### DIFF
--- a/sros2/test/sros2/commands/security/verbs/test_create_key.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_key.py
@@ -34,8 +34,8 @@ from sros2.policy import get_transport_schema
 
 # This fixture will run once for the entire module (as opposed to once per test)
 @pytest.fixture(scope='module')
-def node_keys_dir(tmp_path_factory):
-    keystore_dir = str(tmp_path_factory.mktemp('keystore'))
+def node_keys_dir(tmpdir_factory):
+    keystore_dir = str(tmpdir_factory.mktemp('keystore'))
 
     # First, create the keystore
     assert create_keystore(keystore_dir)

--- a/sros2/test/sros2/commands/security/verbs/test_create_keystore.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_keystore.py
@@ -27,8 +27,8 @@ from sros2.api import _DEFAULT_COMMON_NAME
 
 # This fixture will run once for the entire module (as opposed to once per test)
 @pytest.fixture(scope='module')
-def keystore_dir(tmp_path_factory):
-    keystore_dir = str(tmp_path_factory.mktemp('keystore'))
+def keystore_dir(tmpdir_factory):
+    keystore_dir = str(tmpdir_factory.mktemp('keystore'))
 
     # Create the keystore
     assert cli.main(argv=['security', 'create_keystore', keystore_dir]) == 0


### PR DESCRIPTION
ROS 2 tests are limited by the version of packages available in Ubuntu Bionic, not the ones available in pip. As a result, we need to make sure we only take advantage of the features as of pytest v3.3.2. A side effect of this is that we must use `tmpdir_factory` as opposed to `tmp_path_factory`, which wasn't introduced until v4.3.0.