### PR TITLE
fix certificate start date to work regardless of the timezone

### DIFF
--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -440,17 +440,17 @@ def _build_key_and_cert(subject_name, *, ca=False, ca_key=None, issuer_name=''):
     else:
         extension = x509.BasicConstraints(ca=False, path_length=None)
 
-    now = datetime.datetime.now()
+    utcnow = datetime.datetime.utcnow()
     builder = x509.CertificateBuilder(
         ).issuer_name(
             issuer_name
         ).serial_number(
             x509.random_serial_number()
         ).not_valid_before(
-            now
+            utcnow
         ).not_valid_after(
             # TODO: This should not be hard-coded
-            now + datetime.timedelta(days=3650)
+            utcnow + datetime.timedelta(days=3650)
         ).public_key(
             private_key.public_key()
         ).subject_name(

--- a/sros2/test/sros2/commands/security/verbs/test_create_key.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_key.py
@@ -109,9 +109,9 @@ def test_cert_pem(node_keys_dir):
     assert isinstance(cert.signature_hash_algorithm, hashes.SHA256)
 
     # Verify the cert is valid for the expected timespan
-    now = datetime.datetime.now()
-    assert _datetimes_are_close(cert.not_valid_before, now)
-    assert _datetimes_are_close(cert.not_valid_after, now + datetime.timedelta(days=3650))
+    utcnow = datetime.datetime.utcnow()
+    assert _datetimes_are_close(cert.not_valid_before, utcnow)
+    assert _datetimes_are_close(cert.not_valid_after, utcnow + datetime.timedelta(days=3650))
 
     # Verify that the cert ensures this key cannot be used to sign others as a CA
     assert len(cert.extensions) == 1


### PR DESCRIPTION
Currently if the machine generating the certificate has a local time ahead of UTC, the nodes fail to be created.

This PR switches to uses UTC time for the certificate start and end of validity times.

<details><summary>Error messages</summary>

Fast-RTPS:
```
2019-08-01 02:19:18.354 [SECURITY Error] Error validating the local participant identity. () -> Function init
2019-08-01 02:19:18.355 [RTPS_PARTICIPANT Error] Cannot create participant due to security initialization error -> Function createParticipant
```

Connext:
```
[CREATE Participant]RTI_Security_CertHelper_verifyCert:X509_verify_cert returned 0 with error 9: certificate is not yet valid
[CREATE Participant]RTI_Security_Authentication_get_certificate:failed to verify certificate
[CREATE Participant]RTI_Security_Authentication_validate_local_identity:failed to get certificate
[CREATE Participant]DDS_DomainParticipantTrustPlugins_getLocalParticipantSecurityState:!certificate verify fail
[CREATE Participant]DDS_DomainParticipant_createI:!get local participant security state
[CREATE Participant]DDS_DomainParticipantFactory_create_participant_disabledI:!create participant
DDSDomainParticipant_impl::create_disabledI:!create participant
DDSDomainParticipant_impl::createI:!create participant
DomainParticipantFactory_impl::create_participant():!create failure creating participant
```

</details>

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>