### PR TITLE
generate_artifacts fixup

### DIFF
--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -360,8 +360,9 @@ def generate_artifacts(keystore_path=None, identity_names=[], policy_files=[]):
         profiles_element = policy_tree.find('profiles')
         for profile in profiles_element:
             identity_name = profile.get('ns').rstrip('/') + '/' + profile.get('node')
-            if not create_key(keystore_path, identity_name):
-                return False
+            if identity_name not in identity_names:
+                if not create_key(keystore_path, identity_name):
+                    return False
             policy_element = get_policy_from_tree(identity_name, policy_tree)
             create_permissions_from_policy_element(
                 keystore_path, identity_name, policy_element)

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -256,7 +256,7 @@ def create_permissions_from_policy_element(keystore_path, identity, policy_eleme
     domain_id = os.getenv(DOMAIN_ID_ENV, '0')
     relative_path = os.path.normpath(identity.lstrip('/'))
     key_dir = os.path.join(keystore_path, relative_path)
-    print('key_dir %s' % key_dir)
+    print("creating permission file for identity: '%s'" % identity)
     permissions_path = os.path.join(key_dir, 'permissions.xml')
     create_permission_file(permissions_path, domain_id, policy_element)
 


### PR DESCRIPTION
- sros2/generate_artifacts: currently if an identity is listed both in the `node_names` argument and in the profiles of the policy file provided, the key creation is invoked twice.  https://github.com/ros2/sros2/commit/43ee961ad4741340d97289fae841d806faab0f1d avoids the duplication
- sros2/create_permission: update the debug message to match the one displayed in create_key https://github.com/ros2/sros2/commit/a16240f49b0a51624cff03f1f036d01c369e24f8:

<details>

Before:

```
creating key for identity: '/amcl'
creating cert and key
creating key for identity: '/amcl'
found cert and key; not creating new ones!
key_dir keystore/amcl
```

After:

```
creating key for identity: '/amcl'
creating cert and key
creating permission file for identity: '/amcl'
```

</details>