### PR TITLE
topics starting with tilde need a slash right after

### DIFF
--- a/sros2/sros2/policy/templates/dds/permissions.xsl
+++ b/sros2/sros2/policy/templates/dds/permissions.xsl
@@ -235,7 +235,7 @@
         </xsl:call-template>
       </xsl:variable>
       <xsl:variable name="_name" select="substring($name, 2)"/>
-      <xsl:value-of select="concat($_ns, $node, '/', $_name)"/>
+      <xsl:value-of select="concat($_ns, $node, $_name)"/>
     </xsl:when>
     <xsl:otherwise>
       <xsl:variable name="_ns">

--- a/sros2/sros2/verb/generate_policy.py
+++ b/sros2/sros2/verb/generate_policy.py
@@ -104,7 +104,7 @@ class GeneratePolicyVerb(VerbExtension):
         for expression in expressions:
             permission = etree.Element(permission_type)
             if expression.fqn.startswith(node_name.fqn + '/'):
-                permission.text = '~' + expression.fqn[len(node_name.fqn + '/'):]
+                permission.text = '~' + expression.fqn[len(node_name.fqn):]
             elif expression.fqn.startswith(node_name.ns + '/'):
                 permission.text = expression.fqn[len(node_name.ns + '/'):]
             elif expression.fqn.count('/') == 1 and node_name.ns == '/':

--- a/sros2/test/policies/common/node/parameters.xml
+++ b/sros2/test/policies/common/node/parameters.xml
@@ -5,11 +5,11 @@
   </topics>
 
   <services reply="ALLOW" request="ALLOW" >
-    <service>~describe_parameters</service>
-    <service>~get_parameter_types</service>
-    <service>~get_parameters</service>
-    <service>~list_parameters</service>
-    <service>~set_parameters</service>
-    <service>~set_parameters_atomically</service>
+    <service>~/describe_parameters</service>
+    <service>~/get_parameter_types</service>
+    <service>~/get_parameters</service>
+    <service>~/list_parameters</service>
+    <service>~/set_parameters</service>
+    <service>~/set_parameters_atomically</service>
   </services>
 </profile>


### PR DESCRIPTION
from http://design.ros2.org/articles/topic_and_service_names.html:
> must separate a tilde (~) from the rest of the name with a forward slash (/), i.e. ~/foo not ~foo

Note that there is currently no enforcement that the node or topic names provided in the policy files are valid.
In the future we could consider checking the validity of the node and topic names using the validation functions provided by ROS.
If we do so we may want to introduce a way to bypass the check, and/or better, a separate tag for pure transport topics (to which ROS conventions would not be applied)

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>