### PR TITLE
Fix test_policy_to_permissions test failing when there's no internet

### DIFF
--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -13,6 +13,7 @@
   <depend>rclpy</depend>
   <depend>ros2cli</depend>
 
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-lxml</exec_depend>
   <exec_depend>python3-cryptography</exec_depend>
 

--- a/sros2/setup.py
+++ b/sros2/setup.py
@@ -29,7 +29,7 @@ setup(
         ('share/' + package_name, ['package.xml']),
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
-        ('share/sros2/xml_cache/', glob.glob('xml_cache/**')),
+        ('share/sros2/xml_cache', glob.glob('xml_cache/**')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/sros2/setup.py
+++ b/sros2/setup.py
@@ -1,3 +1,4 @@
+import glob
 import os
 
 from setuptools import find_packages
@@ -28,6 +29,7 @@ setup(
         ('share/' + package_name, ['package.xml']),
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
+        ('share/sros2/xml_cache/', glob.glob('xml_cache/**')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/sros2/sros2/__init__.py
+++ b/sros2/sros2/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import urllib.parse
+import urllib.request
+
+import ament_index_python
+
+
+_xml_cache_path = urllib.request.pathname2url(
+    urllib.parse.urljoin(
+        'file:',
+        os.path.join(
+                ament_index_python.get_package_share_directory('sros2'),
+                'xml_cache',
+                'xhtml-cache.xml'
+        )
+    )
+)
+
+
+if 'XML_CATALOG_FILES' not in os.environ:
+    os.environ['XML_CATALOG_FILES'] = _xml_cache_path
+elif _xml_cache_path not in os.environ['XML_CATALOG_FILES']:
+    os.environ['XML_CATALOG_FILES'] += ' ' + _xml_cache_path

--- a/sros2/sros2/__init__.py
+++ b/sros2/sros2/__init__.py
@@ -19,13 +19,13 @@ import urllib.request
 import ament_index_python
 
 
-_xml_cache_path = urllib.request.pathname2url(
-    urllib.parse.urljoin(
-        'file:',
+_xml_cache_path = urllib.parse.urljoin(
+    'file:',
+    urllib.request.pathname2url(
         os.path.join(
-                ament_index_python.get_package_share_directory('sros2'),
-                'xml_cache',
-                'xhtml-cache.xml'
+            ament_index_python.get_package_share_directory('sros2'),
+            'xml_cache',
+            'xhtml-cache.xml'
         )
     )
 )

--- a/sros2/test/conftest.py
+++ b/sros2/test/conftest.py
@@ -1,0 +1,19 @@
+# Copyright 2019 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+# Disable lxml2 lookup of resources on the internet by configuring it to use a proxy
+# that does not exist
+os.environ['HTTP_PROXY'] = 'http://example.com'

--- a/sros2/test/test_policy_to_permissions.py
+++ b/sros2/test/test_policy_to_permissions.py
@@ -14,7 +14,6 @@
 
 import os
 
-import ament_index_python
 from lxml import etree
 
 from sros2.policy import (
@@ -22,20 +21,6 @@ from sros2.policy import (
     get_transport_schema,
     get_transport_template,
 )
-
-
-if 'XML_CATALOG_FILES' not in os.environ:
-    os.environ['XML_CATALOG_FILES'] = os.path.join(
-        ament_index_python.get_package_share_directory('sros2'),
-        'xml_cache',
-        'xhtml-cache.xml'
-    )
-elif 'xml_cache/xhtml-cache.xml' not in os.environ['XML_CATALOG_FILES']:
-    os.environ['XML_CATALOG_FILES'] += ' ' + os.path.join(
-        ament_index_python.get_package_share_directory('sros2'),
-        'xml_cache',
-        'xhtml-cache.xml'
-    )
 
 
 def test_policy_to_permissions():

--- a/sros2/test/test_policy_to_permissions.py
+++ b/sros2/test/test_policy_to_permissions.py
@@ -14,6 +14,7 @@
 
 import os
 
+import ament_index_python
 from lxml import etree
 
 from sros2.policy import (
@@ -21,6 +22,20 @@ from sros2.policy import (
     get_transport_schema,
     get_transport_template,
 )
+
+
+if 'XML_CATALOG_FILES' not in os.environ:
+    os.environ['XML_CATALOG_FILES'] = os.path.join(
+        ament_index_python.get_package_share_directory('sros2'),
+        'xml_cache',
+        'xhtml-cache.xml'
+    )
+elif 'xml_cache/xhtml-cache.xml' not in os.environ['XML_CATALOG_FILES']:
+    os.environ['XML_CATALOG_FILES'] += ' ' + os.path.join(
+        ament_index_python.get_package_share_directory('sros2'),
+        'xml_cache',
+        'xhtml-cache.xml'
+    )
 
 
 def test_policy_to_permissions():

--- a/sros2/xml_cache/README.md
+++ b/sros2/xml_cache/README.md
@@ -1,0 +1,3 @@
+The file 'xml.xsd' was downloaded from http://www.w3.org/2001/03/xml.xsd and is installed
+along with the sros2 package so the schema lookup will succeed even without an internet
+connection.

--- a/sros2/xml_cache/xhtml-cache.xml
+++ b/sros2/xml_cache/xhtml-cache.xml
@@ -1,0 +1,5 @@
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <rewriteURI
+      uriStartString="http://www.w3.org/2001/03/xml.xsd"
+      rewritePrefix="./xml.xsd" />
+</catalog>

--- a/sros2/xml_cache/xml.xsd
+++ b/sros2/xml_cache/xml.xsd
@@ -1,0 +1,117 @@
+<?xml version='1.0'?>
+<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd" >
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang or xml:space attributes
+        on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .>
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .>
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/>
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2001/03/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself.  In other words, if the XML Schema namespace changes, the version
+   of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2001/03/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang" type="xs:language">
+  <xs:annotation>
+   <xs:documentation>In due course, we should install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values . . .</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attribute name="space" default="preserve">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+ </xs:attributeGroup>
+
+</xs:schema>


### PR DESCRIPTION
This PR does the following:

  * Makes sros2 install an XML catalog to the 'share' directory with a copy of http://www.w3.org/2001/03/xml.xsd
  * ~~Makes test_policy_to_permissions.py use the installed catalog so the test doesn't die when you can't reach www.w3.org~~
  * Makes sros2 modify the XML_CATALOG_FILES environment variable when it's imported so we use the cached schema instead of going out to the internet

### A quick recap
You can observe the original problem by running `colcon test` on the sros2 package without an internet connection.  The test will fail with
```
lxml.etree.XMLSchemaParseError: attribute use (unknown), attribute 'ref': The QName value '{http://www.w3.org/XML/1998/namespace}base' does not resolve to a(n) attribute declaration., line 34
- generated xml file: /path_to_workspace/build/sros2/pytest.xml -
```

After this PR, the test will succeed, even without an internet connection


### Open Questions
~~I have only fixed the test.  The only way I could figure out to get lxml to use the new catalog was to add the path to the XML_CATALOG_FILES environment variable.  I put some extra start-up code in test_policy_to_permissions to append (or create) this environment variable.~~

~~Presumably, we would want to same behavior to happen if you were just using the sros2 package.  I would like to give the package maintainers an opportunity to suggest how to do that.~~

~~If we want to keep the test-only fix, we should make ament_index_python a `test_depend` instead of an `exec_depend`~~

In the latest version of this PR, you get the caching at run time, not just test time


### Reference:
The instructions I (more or less) followed are here: https://www.w3.org/blog/2008/09/caching-xml-data-at-install-ti/


  - Fixes #157