### PR TITLE
Fix missing resources for ament

### DIFF
--- a/sros2/setup.py
+++ b/sros2/setup.py
@@ -18,10 +18,15 @@ extra_files.extend(package_files('sros2/policy/schemas'))
 extra_files.extend(package_files('sros2/policy/templates'))
 
 
+package_name = 'sros2'
+
 setup(
-    name='sros2',
+    name=package_name,
     version='0.6.2',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     zip_safe=True,
     author='Morgan Quigley',

--- a/sros2/setup.py
+++ b/sros2/setup.py
@@ -26,6 +26,8 @@ setup(
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/' + package_name, ['package.xml']),
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
Backport fixing installation of resources needed by ament to 'dashing'

Without this change, I can't build and test https://github.com/ros2/sros2/pull/161 in the ros:dashing docker image without getting the following errors:

```
-------------- generated xml file: /sros2/build/sros2/pytest.xml ---------------
==================================== ERRORS ====================================
_____________ ERROR collecting test/test_policy_to_permissions.py ______________
/opt/ros/dashing/lib/python3.6/site-packages/ament_index_python/packages.py:49: in get_package_prefix
    content, package_prefix = get_resource('packages', package_name)
/opt/ros/dashing/lib/python3.6/site-packages/ament_index_python/resources.py:49: in get_resource
    "Could not find the resource '%s' of type '%s'" % (resource_name, resource_type))
E   LookupError: Could not find the resource 'sros2' of type 'packages'

During handling of the above exception, another exception occurred:
test/test_policy_to_permissions.py:19: in <module>
    from sros2.policy import (
sros2/__init__.py:26: in <module>
    ament_index_python.get_package_share_directory('sros2'),
/opt/ros/dashing/lib/python3.6/site-packages/ament_index_python/packages.py:69: in get_package_share_directory
    return os.path.join(get_package_prefix(package_name), 'share', package_name)
/opt/ros/dashing/lib/python3.6/site-packages/ament_index_python/packages.py:52: in get_package_prefix
    "package '{}' not found, searching: {}".format(package_name, get_search_paths()))
E   ament_index_python.packages.PackageNotFoundError: "package 'sros2' not found, searching: ['/sros2/install/sros2', '/opt/ros/dashing']"
___________________ ERROR collecting test/sros2/test_api.py ____________________
/opt/ros/dashing/lib/python3.6/site-packages/ament_index_python/packages.py:49: in get_package_prefix
    content, package_prefix = get_resource('packages', package_name)
/opt/ros/dashing/lib/python3.6/site-packages/ament_index_python/resources.py:49: in get_resource
    "Could not find the resource '%s' of type '%s'" % (resource_name, resource_type))
E   LookupError: Could not find the resource 'sros2' of type 'packages'

During handling of the above exception, another exception occurred:
test/sros2/test_api.py:15: in <module>
    from sros2.api import is_key_name_valid
sros2/__init__.py:26: in <module>
    ament_index_python.get_package_share_directory('sros2'),
/opt/ros/dashing/lib/python3.6/site-packages/ament_index_python/packages.py:69: in get_package_share_directory
    return os.path.join(get_package_prefix(package_name), 'share', package_name)
/opt/ros/dashing/lib/python3.6/site-packages/ament_index_python/packages.py:52: in get_package_prefix
    "package '{}' not found, searching: {}".format(package_name, get_search_paths()))
E   ament_index_python.packages.PackageNotFoundError: "package 'sros2' not found, searching: ['/sros2/install/sros2', '/opt/ros/dashing']"
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
=========================== 2 error in 0.20 seconds ============================
```