### PR TITLE
point to versionned version of the tutorial for users not using latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The security feature is tested across platforms (Linux, macOS, and Windows) as w
 Although we are designing SROS2 to work with any secure middleware, at the moment we are testing with RTI Connext Secure 5.3.1 and eProsima's Fast-RTPS 1.6.0.
 If you want to run the demo using RTI Connext Secure you will need a license for it and you will need to install it.
 
+These Tutorials are written for the latest state of the repository.
+If you are using an older ROS 2 distribution please refer to the tutorials on the branch named after the distribution, e.g. for Crystal: https://github.com/ros2/sros2/blob/crystal/README.md
 
 [Try SROS2 on Linux](SROS2_Linux.md)
 

--- a/SROS2_Linux.md
+++ b/SROS2_Linux.md
@@ -31,9 +31,6 @@ colcon build --symlink-install --cmake-args -DSECURITY=ON
 Prerequisite: to use DDS-Security with Connext you will need to procure an RTI Licence and install the security plugins (note that you also need to install RTI's version of openssl as 5.3.1 doesnt support openssl 1.1.0 provided in Ubuntu Bionic).
 See [this page](https://index.ros.org/doc/ros2/Installation/Install-Connext-Security-Plugins) for details on installing the security plugins.
 
-Warning: this tutorial is for ROS Bouncy and Connext 5.3.1.
-If you use ROS Ardent or Connext 5.3.0 please refer to the [tutorial from ROS Ardent](https://github.com/ros2/sros2/blob/ardent/SROS2_Linux.md)
-
 The RTI Connext installer allows you to choose where it lands in the filesystem.
 These instructions assume that you have prefixed the RTI paths with `$HOME/rti` so that the latest version will land in `$HOME/rti/rti_connext_dds-5.3.1`.
 Note that the installer is a multi-partprocess.


### PR DESCRIPTION
The current wording can be confusing to users: https://answers.ros.org/question/335665/sros2-on-ros2-dashing/

Note that this needs relative links to be used and not absolute within the docs content requiring something like https://github.com/ros2/sros2/pull/102/files to be (partially) backported

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>