### PR TITLE
move to demo directory before pulling policies

### DIFF
--- a/SROS2_Linux.md
+++ b/SROS2_Linux.md
@@ -174,6 +174,7 @@ To do this, we will use the sample policy file provided in `examples/sample_poli
 First, we will copy this sample policy file into our keystore:
 
 ```bash
+cd ~/sros2_demo
 svn checkout https://github.com/ros2/sros2/trunk/sros2/test/policies
 ```
 


### PR DESCRIPTION
If users do the multi-machine part of the demo they'd end up in a different directory.
This ensures they're back in the demo directory before pulling policies and generating permissions.

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>