### PR TITLE
Set rtps_protection_kind to ENCRYPT by default

### DIFF
--- a/sros2/sros2/policy/defaults/dds/governance.xml
+++ b/sros2/sros2/policy/defaults/dds/governance.xml
@@ -10,7 +10,7 @@
             <enable_join_access_control>true</enable_join_access_control>
             <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
             <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
-            <rtps_protection_kind>SIGN</rtps_protection_kind>
+            <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
             <topic_access_rules>
                 <topic_rule>
                     <topic_expression>*</topic_expression>


### PR DESCRIPTION
Currently, sros2 defaults leak node-related information from which an attacker can obtain additional information about the ROS graph.

This issue was discussed during the [Security workshop at ROSCon 2019](https://ros-swg.github.io/ROSCon19_Security_Workshop/) (credit and thanks to @mikaelarguedas for pointing out the fix).  In addition and for compleness, the flaw has been captured at the following ticket within the Robot Vulnerability Database (RVD): https://github.com/aliasrobotics/RVD/issues/922

A reproduction of this bug with the latest ROS 2 (master, `foxy`) packages is illustrated in https://asciinema.org/a/SSnSAMlOEoHfqhAuzC1R98STF. The same issue has been confirmed for `dashing` and `eloquent`.