### PR TITLE
Symlink CA certs instead of copy

### DIFF
--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -287,7 +287,12 @@ def create_key(keystore_path, identity):
     for public_cert in public_certs:
         dst = os.path.join(key_dir, public_cert)
         relativepath = os.path.relpath(keystore_ca_cert_path, key_dir)
-        os.symlink(src=relativepath, dst=dst)
+        try:
+            os.symlink(src=relativepath, dst=dst)
+        except FileExistsError as e:
+            if not os.path.samefile(keystore_ca_cert_path, dst):
+                print('Existing symlink does not mach!')
+                raise RuntimeError(str(e))
 
     # copy the governance file in there
     keystore_governance_path = os.path.join(keystore_path, 'governance.p7s')

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -291,7 +291,7 @@ def create_key(keystore_path, identity):
             os.symlink(src=relativepath, dst=dst)
         except FileExistsError as e:
             if not os.path.samefile(keystore_ca_cert_path, dst):
-                print('Existing symlink does not mach!')
+                print('Existing symlink does not match!')
                 raise RuntimeError(str(e))
 
     # copy the governance file in there

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -279,12 +279,14 @@ def create_key(keystore_path, identity):
     key_dir = os.path.join(keystore_path, relative_path)
     os.makedirs(key_dir, exist_ok=True)
 
+    keystore_ca_key_path = os.path.join(keystore_path, 'ca.key.pem')
+    keystore_ca_cert_path = os.path.join(keystore_path, 'ca.cert.pem')
+
     # symlink the CA cert in there
     public_certs = ['identity_ca.cert.pem', 'permissions_ca.cert.pem']
     for public_cert in public_certs:
-            src = os.path.join(keystore_path, 'ca.cert.pem')
             dst = os.path.join(key_dir, public_cert)
-            relativepath = os.path.relpath(src, key_dir)
+            relativepath = os.path.relpath(keystore_ca_cert_path, key_dir)
             os.symlink(src=relativepath, dst=dst)
 
     # copy the governance file in there

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -285,9 +285,9 @@ def create_key(keystore_path, identity):
     # symlink the CA cert in there
     public_certs = ['identity_ca.cert.pem', 'permissions_ca.cert.pem']
     for public_cert in public_certs:
-            dst = os.path.join(key_dir, public_cert)
-            relativepath = os.path.relpath(keystore_ca_cert_path, key_dir)
-            os.symlink(src=relativepath, dst=dst)
+        dst = os.path.join(key_dir, public_cert)
+        relativepath = os.path.relpath(keystore_ca_cert_path, key_dir)
+        os.symlink(src=relativepath, dst=dst)
 
     # copy the governance file in there
     keystore_governance_path = os.path.join(keystore_path, 'governance.p7s')

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -279,13 +279,13 @@ def create_key(keystore_path, identity):
     key_dir = os.path.join(keystore_path, relative_path)
     os.makedirs(key_dir, exist_ok=True)
 
-    # copy the CA cert in there
-    keystore_ca_key_path = os.path.join(keystore_path, 'ca.key.pem')
-    keystore_ca_cert_path = os.path.join(keystore_path, 'ca.cert.pem')
-    dest_identity_ca_cert_path = os.path.join(key_dir, 'identity_ca.cert.pem')
-    dest_permissions_ca_cert_path = os.path.join(key_dir, 'permissions_ca.cert.pem')
-    shutil.copyfile(keystore_ca_cert_path, dest_identity_ca_cert_path)
-    shutil.copyfile(keystore_ca_cert_path, dest_permissions_ca_cert_path)
+    # symlink the CA cert in there
+    public_certs = ['identity_ca.cert.pem', 'permissions_ca.cert.pem']
+    for public_cert in public_certs:
+            src = os.path.join(keystore_path, 'ca.cert.pem')
+            dst = os.path.join(key_dir, public_cert)
+            relativepath = os.path.relpath(src, key_dir)
+            os.symlink(src=relativepath, dst=dst)
 
     # copy the governance file in there
     keystore_governance_path = os.path.join(keystore_path, 'governance.p7s')


### PR DESCRIPTION
This was a previous approach used with Keymint to prevent the keystore from falling out of sync with itself when renewing CA certs, as well as disk size down by avoiding the duplication of CA cert files. I'd like to test this against all RMW/OS combinations in CI to check which may not support symlinks.

Example:
https://github.com/keymint/keymint_tools/blob/9f5bda35dae4ddc927a7f70f2d961451c150f7c0/keymint_tools/build_types/keymint_ros2_dds.py#L167-L172