### PR TITLE
Add GitHub actions for linting and source-build CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "ros_ws/src/sros2/::"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,9 @@ jobs:
         apt-get -qq update
         apt-get -qq upgrade -y
         rosdep update
-        rosdep install -y --from-paths . --ignore-src --rosdistro foxy
-    - run: . /opt/ros/foxy/setup.sh && colcon build
-    - run: . /opt/ros/foxy/setup.sh && colcon test
+        rosdep install -y --from-paths . --ignore-src --rosdistro $ROS_DISTRO
+    - run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon build
+    - run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon test
     - run: colcon test-result
     - name: Upload Logs
       uses: actions/upload-artifact@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         rosdep update
         rosdep install -y --from-paths . --ignore-src --rosdistro $ROS_DISTRO
     - run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon build
-    - run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon test
+    - run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon test --executor sequential --event-handlers console_direct+
     - run: colcon test-result
     - name: Upload Logs
       uses: actions/upload-artifact@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
   schedule:
     # Run daily
-    - cron:  '0 12 * * *'
+    - cron:  '0 20 * * *'
 
 jobs:
   test_latest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,9 @@ jobs:
         package-name: |
           sros2
           sros2_cmake
-          # commented for now https://github.com/eProsima/Fast-RTPS/issues/1087
-          # test_security
+        # skipping end-to-end tests for now https://github.com/eProsima/Fast-RTPS/issues/1087
+        #  test_security
+        # extra-cmake-args: '-DSECURITY=ON --no-warn-unused-cli'
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.0.6
       if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+name: Test sros2
+on:
+  pull_request:
+  push:
+  schedule:
+    # Run daily
+    - cron:  '0 12 * * *'
+
+jobs:
+  test_latest:
+    runs-on: ubuntu-latest
+    container: osrf/ros2:devel
+    steps:
+    - run: |
+        apt-get -qq update
+        apt-get -qq upgrade -y
+        apt-get -qq install -y curl libasio-dev libtinyxml2-dev
+    - uses: mikaelarguedas/action-ros-ci@sros2-version
+      with:
+        package-name: |
+          sros2
+          sros2_cmake
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1.0.6
+      if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+      with:
+        file: ros_ws/build/sros2/coverage.xml
+        flags: unittests
+        name: sros2-coverage
+        fail_ci_if_error: true
+        yml: .codecov.yml
+    - name: Upload Logs
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: colcon-logs
+        path: ros_ws/log
+  test_nightly:
+    runs-on: ubuntu-latest
+    container: osrf/ros2:nightly
+    steps:
+    - uses: actions/checkout@v1
+    - run: |
+        apt-get -qq update
+        apt-get -qq upgrade -y
+        rosdep update
+        rosdep install -y --from-paths . --ignore-src --rosdistro foxy
+    - run: . /opt/ros/foxy/setup.sh && colcon build
+    - run: . /opt/ros/foxy/setup.sh && colcon test
+    - run: colcon test-result
+    - name: Upload Logs
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: colcon-logs
+        path: ros_ws/log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
         apt-get -qq update
         apt-get -qq upgrade -y
         apt-get -qq install -y curl libasio-dev libtinyxml2-dev
+    # TODO(mikaelarguedas) switch back to ros-tooling/action-ros-ci once
+    # https://github.com/ros-tooling/action-ros-ci/pull/109 is released
     - uses: mikaelarguedas/action-ros-ci@sros2-version
       with:
         package-name: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test sros2
+name: SROS2 CI
 on:
   pull_request:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
         package-name: |
           sros2
           sros2_cmake
+          # commented for now https://github.com/eProsima/Fast-RTPS/issues/1087
+          # test_security
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.0.6
       if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Context
 
+![SROS2 CI](https://github.com/ros2/sros2/workflows/SROS2%20CI/badge.svg)
+[![codecov](https://codecov.io/gh/ros2/sros2/branch/master/graph/badge.svg)](https://codecov.io/gh/ros2/sros2)
+
 This package provides the tools and instructions to use ROS2 on top of DDS-Security.
 The security feature is tested across platforms (Linux, macOS, and Windows) as well as across different languages (C++ and Python).
 

--- a/sros2/.coveragerc
+++ b/sros2/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    # omit test directory
+    test/*


### PR DESCRIPTION
Currently Ubuntu only and no xmllint test for `sros2` due to schema hosting issue.

Looking for feedback on the following:
- the test workflow runs daily
- the lint workflow runs on push and PR events only
- log upload: usefulness of uploading colcon logs?
  Some repositories using the ROS github actions upload the colcon logs (e.g. [rosbag2](https://github.com/ros2/rosbag2/blob/f3228aa784ea15066ede01898f009a0d2de47c34/.github/workflows/test.yml#L20)) but they upload them only on job success, which doesn't seem very useful. I opted to not add that upload step until we come across cases where we need the logs.
 
Examples of jobs using these parameters:
Build + test: https://github.com/mikaelarguedas/sros2/actions/runs/56872161
Lint: https://github.com/mikaelarguedas/sros2/actions/runs/56872157

---

Failing on Macos for now, haven't tried windows:

<details>

```
E   RuntimeError: Failed to initialize init_options: failed to find shared library of rmw implementation. Searched rmw_fastrtps_cpp, at /Users/runner/runners/2.165.2/work/sros2/sros2/ros_ws/src/ros2/rmw_implementation/rmw_implementation/src/functions.cpp:61, at /Users/runner/runners/2.165.2/work/sros2/sros2/ros_ws/src/ros2/rcl/rcl/src/rcl/init_options.c:55
```

</details>

Possible reason: environment may be sanitized (maybe SIP is enabled) so the relevant libs are not on the `DYLD_LIBRARY_PATH`: upstream ticket  https://github.com/ros-tooling/action-ros-ci/issues/81

@kyrofa did you ever succeed to run some ROS nodes on MacOS using this action ?