### PR TITLE
use test_msgs instead of std_{msgs,srvs} packages for testing

### DIFF
--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -22,8 +22,7 @@
   <test_depend>ament_mypy</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>std_msgs</test_depend>
-  <test_depend>std_srvs</test_depend>
+  <test_depend>test_msgs</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/sros2/test/sros2/commands/security/verbs/test_generate_policy.py
+++ b/sros2/test/sros2/commands/security/verbs/test_generate_policy.py
@@ -20,8 +20,8 @@ import pytest
 import rclpy
 from ros2cli import cli
 from sros2.policy import load_policy
-from std_msgs.msg import String
-from std_srvs.srv import Trigger
+from test_msgs.msg import Strings
+from test_msgs.srv import Empty
 
 
 def test_generate_policy_topics():
@@ -33,9 +33,9 @@ def test_generate_policy_topics():
 
         try:
             # Create a publisher and subscription
-            node.create_publisher(String, 'test_generate_policy_topics_pub', 1)
+            node.create_publisher(Strings, 'test_generate_policy_topics_pub', 1)
             node.create_subscription(
-                String, 'test_generate_policy_topics_sub', lambda msg: None, 1)
+                Strings, 'test_generate_policy_topics_sub', lambda msg: None, 1)
 
             # Generate the policy for the running node
             assert cli.main(
@@ -74,8 +74,8 @@ def test_generate_policy_services():
 
         try:
             # Create a server and client
-            node.create_client(Trigger, 'test_generate_policy_services_client')
-            node.create_service(Trigger, 'test_generate_policy_services_server', lambda request,
+            node.create_client(Empty, 'test_generate_policy_services_client')
+            node.create_service(Empty, 'test_generate_policy_services_server', lambda request,
                                 response: response)
 
             # Generate the policy for the running node


### PR DESCRIPTION
as this is the raison-d'etre of the `test_msgs` package and will save non-negligible build time to avoid building those packages.

E.g. from https://ci.ros2.org/job/ci_osx/7955/console
```
Finished <<< std_msgs [14min 37s]
```