### PR TITLE
Bump checkout to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,14 +45,18 @@ jobs:
     container: osrf/ros2:nightly
     steps:
     - uses: actions/checkout@v2
-    - run: |
+    - name: Installing dependencies
+      run: |
         apt-get -qq update
         apt-get -qq upgrade -y
         rosdep update
         rosdep install -y --from-paths . --ignore-src --rosdistro $ROS_DISTRO
-    - run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon build
-    - run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon test --executor sequential --event-handlers console_direct+
-    - run: colcon test-result
+    - name: Build workspace
+      run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon build
+    - name: Test workspace
+      run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon test --executor sequential --event-handlers console_direct+
+    - name: Check test results
+      run: colcon test-result
     - name: Upload Logs
       uses: actions/upload-artifact@v1
       if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     container: osrf/ros2:nightly
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: |
         apt-get -qq update
         apt-get -qq upgrade -y


### PR DESCRIPTION
Checkout v1 has multiple issues, some that are causing build failures:
- unable to checkout on job rerun https://github.com/actions/checkout/issues/23
- not filling PR number correctly on job rerun https://github.com/actions/checkout/issues/58#issuecomment-589447479

This should hopefully address those.

Second commit is unrelated and for nicer prints in the job console output

@kyrofa FYI