### PR TITLE
api: reorganize artifact generation API

### DIFF
--- a/sros2/sros2/api/_artifact_generation.py
+++ b/sros2/sros2/api/_artifact_generation.py
@@ -1,0 +1,44 @@
+# Copyright 2016-2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sros2.policy import load_policy
+
+from . import _key, _keystore, _permission, _policy, _utilities
+
+
+def generate_artifacts(keystore_path=None, identity_names=[], policy_files=[]):
+    if keystore_path is None:
+        keystore_path = _utilities.get_keystore_path_from_env()
+        if keystore_path is None:
+            return False
+    if not _keystore.is_valid_keystore(keystore_path):
+        print('%s is not a valid keystore, creating new keystore' % keystore_path)
+        _keystore.create_keystore(keystore_path)
+
+    # create keys for all provided identities
+    for identity in identity_names:
+        if not _key.create_key(keystore_path, identity):
+            return False
+    for policy_file in policy_files:
+        policy_tree = load_policy(policy_file)
+        contexts_element = policy_tree.find('contexts')
+        for context in contexts_element:
+            identity_name = context.get('path')
+            if identity_name not in identity_names:
+                if not _key.create_key(keystore_path, identity_name):
+                    return False
+            policy_element = _policy.get_policy_from_tree(identity_name, policy_tree)
+            _permission.create_permissions_from_policy_element(
+                keystore_path, identity_name, policy_element)
+    return True

--- a/sros2/sros2/api/_utilities.py
+++ b/sros2/sros2/api/_utilities.py
@@ -15,6 +15,7 @@
 
 import datetime
 import os
+import sys
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend as cryptography_backend
@@ -24,6 +25,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
 _DOMAIN_ID_ENV = 'ROS_DOMAIN_ID'
+_KEYSTORE_DIR_ENV = 'ROS_SECURITY_ROOT_DIRECTORY'
 
 
 def create_symlink(*, src, dst):
@@ -38,6 +40,13 @@ def create_symlink(*, src, dst):
 
 def domain_id() -> str:
     return os.getenv(_DOMAIN_ID_ENV, '0')
+
+
+def get_keystore_path_from_env():
+    root_keystore_path = os.getenv(_KEYSTORE_DIR_ENV)
+    if root_keystore_path is None:
+        print('%s is empty' % _KEYSTORE_DIR_ENV, file=sys.stderr)
+    return root_keystore_path
 
 
 def create_smime_signed_file(cert_path, key_path, unsigned_file_path, signed_file_path):

--- a/sros2/sros2/verb/generate_artifacts.py
+++ b/sros2/sros2/verb/generate_artifacts.py
@@ -23,7 +23,7 @@ except ImportError:
     def FilesCompleter(*, allowednames, directories):
         return None
 
-from sros2.api import generate_artifacts
+from sros2.api import _artifact_generation
 from sros2.verb import VerbExtension
 
 
@@ -44,7 +44,7 @@ class GenerateArtifactsVerb(VerbExtension):
 
     def main(self, *, args):
         try:
-            success = generate_artifacts(
+            success = _artifact_generation.generate_artifacts(
                 args.keystore_root_path, args.security_contexts, args.policy_files)
         except FileNotFoundError as e:
             raise RuntimeError(str(e))


### PR DESCRIPTION
This PR continues the reorganization of #188 by extracting the artifact generation API into its own module.

Note that this introduces no behavioral changes, it's just moving code around.