### PR TITLE
reenable test_generate_policy_no_policy_file

### DIFF
--- a/sros2/test/sros2/commands/security/verbs/test_generate_policy.py
+++ b/sros2/test/sros2/commands/security/verbs/test_generate_policy.py
@@ -136,7 +136,6 @@ def test_generate_policy_no_nodes(capsys):
         assert stderr == 'No nodes detected in the ROS graph. No policy file was generated.'
 
 
-@pytest.mark.skip(reason='temporarily deactivated')
 def test_generate_policy_no_policy_file(capsys):
     with pytest.raises(SystemExit) as e:
         cli.main(argv=['security', 'generate_policy'])


### PR DESCRIPTION
follow up of https://github.com/ros2/sros2/pull/203

Reenable test disabled in https://github.com/ros2/sros2/pull/177