### PR TITLE
reenable test_security on master builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,8 @@ jobs:
         package-name: |
           sros2
           sros2_cmake
-        # skipping end-to-end tests for now https://github.com/eProsima/Fast-RTPS/issues/1087
-        #  test_security
-        # extra-cmake-args: '-DSECURITY=ON --no-warn-unused-cli'
+          test_security
+        extra-cmake-args: '-DSECURITY=ON --no-warn-unused-cli'
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.0.6
       if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')


### PR DESCRIPTION
this will currently only run linters on test_security, but once https://github.com/ros2/system_tests/pull/415 is merged it will test the fastrtps security tests on a daily basis, so we will get notified of any breakage