### PR TITLE
start valid date a day before to account for timezone mismatch

### DIFF
--- a/sros2/sros2/api/_utilities.py
+++ b/sros2/sros2/api/_utilities.py
@@ -87,6 +87,9 @@ def build_key_and_cert(subject_name, *, ca=False, ca_key=None, issuer_name=''):
         ).serial_number(
             x509.random_serial_number()
         ).not_valid_before(
+            # Using a day earlier here to prevent Connext (5.3.1) from complaining
+            # when extracting it from the permissions file and thinking it's in the future
+            # https://github.com/ros2/ci/pull/436#issuecomment-624874296
             utcnow - datetime.timedelta(days=1)
         ).not_valid_after(
             # TODO: This should not be hard-coded

--- a/sros2/sros2/api/_utilities.py
+++ b/sros2/sros2/api/_utilities.py
@@ -87,7 +87,7 @@ def build_key_and_cert(subject_name, *, ca=False, ca_key=None, issuer_name=''):
         ).serial_number(
             x509.random_serial_number()
         ).not_valid_before(
-            utcnow
+            utcnow - datetime.timedelta(days=1)
         ).not_valid_after(
             # TODO: This should not be hard-coded
             utcnow + datetime.timedelta(days=3650)

--- a/sros2/test/sros2/commands/security/verbs/test_create_key.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_key.py
@@ -104,6 +104,10 @@ def test_cert_pem(enclave_keys_dir):
 
     # Verify the cert is valid for the expected timespan
     utcnow = datetime.datetime.utcnow()
+
+    # Using a day earlier here to prevent Connext (5.3.1) from complaining
+    # when extracting it from the permissions file and thinking it's in the future
+    # https://github.com/ros2/ci/pull/436#issuecomment-624874296
     assert _datetimes_are_close(cert.not_valid_before, utcnow - datetime.timedelta(days=1))
     assert _datetimes_are_close(cert.not_valid_after, utcnow + datetime.timedelta(days=3650))
 

--- a/sros2/test/sros2/commands/security/verbs/test_create_key.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_key.py
@@ -104,7 +104,7 @@ def test_cert_pem(enclave_keys_dir):
 
     # Verify the cert is valid for the expected timespan
     utcnow = datetime.datetime.utcnow()
-    assert _datetimes_are_close(cert.not_valid_before, utcnow)
+    assert _datetimes_are_close(cert.not_valid_before, utcnow - datetime.timedelta(days=1))
     assert _datetimes_are_close(cert.not_valid_after, utcnow + datetime.timedelta(days=3650))
 
     # Verify that the cert ensures this key cannot be used to sign others as a CA


### PR DESCRIPTION
apparently https://github.com/ros2/sros2/pull/205 broke Connext

Opening as draft for now pending testing and then CI