### PR TITLE
use nightly image including all 3 RMWs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test_latest:
     runs-on: ubuntu-latest
+    # 'osrf/ros2:devel' does *not* include RTI Connext or its' security plugins
+    # the former gets installed via rosdep in 'action-ros-ci' but the latter do *not* get installed
     container: osrf/ros2:devel
     steps:
     - name: Install prerequisites for action-ros-ci and FastRTPS
@@ -42,6 +44,8 @@ jobs:
         path: ros_ws/log
   test_nightly:
     runs-on: ubuntu-latest
+    # 'osrf/ros2:nightly-rmw-nonfree' includes RTI Connext but
+    # does *not* include the security plugins or a license allowing the use of Security
     container: osrf/ros2:nightly-rmw-nonfree
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         path: ros_ws/log
   test_nightly:
     runs-on: ubuntu-latest
-    container: osrf/ros2:nightly
+    container: osrf/ros2:nightly-rmw-nonfree
     steps:
     - uses: actions/checkout@v2
     - name: Installing dependencies


### PR DESCRIPTION
This will unlock PRs adding tests for multiple RMW implementations such as https://github.com/ros2/sros2/pull/214

For now no test expect security DDS plugins to be installed. If that becomes the case we would need to either blacklist connext or find a way for the tests to fetch a license with security support and install the security plugins.