### PR TITLE
Fix list keys verb

### DIFF
--- a/sros2/sros2/api/_key.py
+++ b/sros2/sros2/api/_key.py
@@ -111,7 +111,7 @@ def list_keys(keystore_path):
     p = pathlib.Path(enclaves_path)
     key_file_paths = sorted(p.glob('**/key.pem'))
     for key_file_path in key_file_paths:
-        print('/{}'.format(key_file_path.parent.relative_to(enclaves_path)))
+        print('/{}'.format(key_file_path.parent.relative_to(enclaves_path).as_posix()))
     return True
 
 

--- a/sros2/sros2/api/_key.py
+++ b/sros2/sros2/api/_key.py
@@ -15,6 +15,7 @@
 
 import errno
 import os
+import pathlib
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend as cryptography_backend
@@ -103,12 +104,14 @@ def create_key(keystore_path, identity):
 def list_keys(keystore_path):
     enclaves_path = _keystore.get_keystore_enclaves_dir(keystore_path)
     if not os.path.isdir(keystore_path):
-        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), keystore_path)
+        raise FileNotFoundError(
+            errno.ENOENT, os.strerror(errno.ENOENT), keystore_path)
     if not os.path.isdir(enclaves_path):
         return True
-    for name in os.listdir(enclaves_path):
-        if os.path.isdir(os.path.join(enclaves_path, name)):
-            print(name)
+    p = pathlib.Path(enclaves_path)
+    key_file_paths = sorted(p.glob('**/key.pem'))
+    for key_file_path in key_file_paths:
+        print('/{}'.format(key_file_path.parent.relative_to(enclaves_path)))
     return True
 
 

--- a/sros2/test/sros2/commands/security/verbs/test_list_keys.py
+++ b/sros2/test/sros2/commands/security/verbs/test_list_keys.py
@@ -32,7 +32,7 @@ def test_list_keys(capsys):
 
         # Now verify that the key we just created is included in the list
         assert cli.main(argv=['security', 'list_keys', keystore_dir]) == 0
-        assert (capsys.readouterr().out.strip() == '\n'.join(sorted(enclave_names)))
+        assert capsys.readouterr().out.strip() == '\n'.join(sorted(enclave_names))
 
 
 def test_list_keys_no_keys(capsys):

--- a/sros2/test/sros2/commands/security/verbs/test_list_keys.py
+++ b/sros2/test/sros2/commands/security/verbs/test_list_keys.py
@@ -20,17 +20,19 @@ from sros2.api import _key, _keystore
 
 
 def test_list_keys(capsys):
+    enclave_names = ['/test_enclave', '/test/nested_enclave', '/sky/is/the/limit']
     with tempfile.TemporaryDirectory() as keystore_dir:
         with capsys.disabled():
             # First, create the keystore
             assert _keystore.create_keystore(keystore_dir)
 
             # Now using that keystore, create a keypair
-            assert _key.create_key(keystore_dir, '/test_enclave')
+            for enclave_name in enclave_names:
+                assert _key.create_key(keystore_dir, enclave_name)
 
         # Now verify that the key we just created is included in the list
         assert cli.main(argv=['security', 'list_keys', keystore_dir]) == 0
-        assert capsys.readouterr().out.strip() == 'test_enclave'
+        assert (capsys.readouterr().out.strip() == '\n'.join(sorted(enclave_names)))
 
 
 def test_list_keys_no_keys(capsys):


### PR DESCRIPTION
Fixes https://github.com/ros2/sros2/issues/183
setup: 
`ros2 security generate_artifacts -k keystore -e /foo /foobar/baz /bar /a/b/c/deep`

before:
```
root@5ab52a51093c:/ws# ros2 security list_keys keystore/
foobar
bar
foo
a

```
after:
```
root@5ab52a51093c:/ws# ros2 security list_keys keystore/
/a/b/c/deep
/bar
/foo
/foobar/baz
```

Note: a similar fix could be backported to Eloquent and Dashing