### PR TITLE
Eloquent backports

### DIFF
--- a/SROS2_Linux.md
+++ b/SROS2_Linux.md
@@ -119,7 +119,7 @@ However, other nodes will not be able to communicate, e.g. the following invocat
 
 ```bash
 # This will fail because the node name does not have valid keys/certificates
-ros2 run demo_nodes_cpp talker __node:=not_talker
+ros2 run demo_nodes_cpp talker --ros-args -r __node:=not_talker
 ```
 
 
@@ -207,5 +207,5 @@ For example, the following attempt for the `listener` node to subscribe to a top
 
 ```bash
 # This will fail because the node is not permitted to subscribe to topics other than chatter.
-ros2 run demo_nodes_py listener chatter:=not_chatter
+ros2 run demo_nodes_py listener --ros-args -r chatter:=not_chatter
 ```

--- a/SROS2_MacOS.md
+++ b/SROS2_MacOS.md
@@ -129,7 +129,7 @@ However, other nodes will not be able to communicate, e.g. the following invocat
 
 ```bash
 # This will fail because the node name does not have valid keys/certificates
-ros2 run demo_nodes_cpp talker __node:=not_talker
+ros2 run demo_nodes_cpp talker --ros-args -r __node:=not_talker
 ```
 
 
@@ -175,5 +175,5 @@ For example, the following attempt for the `listener` node to subscribe to a top
 
 ```bash
 # This will fail because the node is not permitted to subscribe to topics other than chatter.
-ros2 run demo_nodes_py listener chatter:=not_chatter
+ros2 run demo_nodes_py listener --ros-args -r chatter:=not_chatter
 ```

--- a/SROS2_Windows.md
+++ b/SROS2_Windows.md
@@ -128,7 +128,7 @@ However, other nodes will not be able to communicate, e.g. the following invocat
 
 ```bat
 REM This will fail because the node name does not have valid keys/certificates
-ros2 run demo_nodes_cpp talker __node:=not_talker
+ros2 run demo_nodes_cpp talker --ros-args -r __node:=not_talker
 ```
 
 ### Access Control
@@ -173,5 +173,5 @@ For example, the following attempt for the `listener` node to subscribe to a top
 
 ```bat
 REM This will fail because the node is not permitted to subscribe to topics other than chatter.
-ros2 run demo_nodes_py listener chatter:=not_chatter
+ros2 run demo_nodes_py listener --ros-args -r chatter:=not_chatter
 ```

--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>sros2</name>
   <version>0.8.1</version>
   <description>Command line tools for managing SROS2 keys</description>
-  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="ros-security@googlegroups.com">ROS Security Working Group</maintainer>
   <license>Apache License 2.0</license>
 
   <author email="morgan@osrfoundation.org">Morgan Quigley</author>

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -14,7 +14,9 @@
 
 from collections import namedtuple
 import datetime
+import errno
 import os
+import pathlib
 import shutil
 import sys
 
@@ -324,9 +326,13 @@ def create_key(keystore_path, identity):
 
 
 def list_keys(keystore_path):
-    for name in os.listdir(keystore_path):
-        if os.path.isdir(os.path.join(keystore_path, name)):
-            print(name)
+    if not os.path.isdir(keystore_path):
+        raise FileNotFoundError(
+            errno.ENOENT, os.strerror(errno.ENOENT), keystore_path)
+    p = pathlib.Path(keystore_path)
+    key_file_paths = sorted(p.glob('**/key.pem'))
+    for key_file_path in key_file_paths:
+        print('/{}'.format(key_file_path.parent.relative_to(keystore_path).as_posix()))
     return True
 
 

--- a/sros2/test/sros2/commands/security/verbs/test_list_keys.py
+++ b/sros2/test/sros2/commands/security/verbs/test_list_keys.py
@@ -20,17 +20,19 @@ from sros2.api import create_key, create_keystore
 
 
 def test_list_keys(capsys):
+    key_names = ['/test_node', '/test_namespace/test_node', '/sky/is/the/limit']
     with tempfile.TemporaryDirectory() as keystore_dir:
         with capsys.disabled():
             # First, create the keystore
             assert create_keystore(keystore_dir)
 
             # Now using that keystore, create a keypair
-            assert create_key(keystore_dir, '/test_node')
+            for key in key_names:
+                assert create_key(keystore_dir, key)
 
         # Now verify that the key we just created is included in the list
         assert cli.main(argv=['security', 'list_keys', keystore_dir]) == 0
-        assert capsys.readouterr().out.strip() == 'test_node'
+        assert capsys.readouterr().out.strip() == '\n'.join(sorted(key_names))
 
 
 def test_list_keys_no_keys(capsys):

--- a/sros2_cmake/package.xml
+++ b/sros2_cmake/package.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0"?>
-    <package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+
+    <package format="3">
     <name>sros2_cmake</name>
     <version>0.8.1</version>
-    <description>Cmake macros to configure security for nodes</description>
-    <author email="ros-contributions@amazon.com">AWS RoboMaker</author>
-    <maintainer email="ros-contributions@amazon.com">AWS RoboMaker</maintainer>
-    <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+    <description>CMake macros to configure security for nodes</description>
+    <maintainer email="ros-security@googlegroups.com">ROS Security Working Group</maintainer>
     <license>Apache 2.0</license>
+
+    <author>AWS RoboMaker</author>
 
     <buildtool_depend>ament_cmake</buildtool_depend>
 
     <build_depend>ament_cmake_test</build_depend>
 
-    <build_export_depend>sros2</build_export_depend>
     <build_export_depend>ros2cli</build_export_depend>
+    <build_export_depend>sros2</build_export_depend>
 
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Backport from Foxy initial release to Eloquent:

## Backported:
- https://github.com/ros2/sros2/pull/170: Update tutorials for Eloquent-style ros arguments: Documentation
- https://github.com/ros2/sros2/pull/179: Update maintainer and package.xml : book keeping
- https://github.com/ros2/sros2/pull/219: Fix list keys verb: bugfix

## Non-Backported:
- Use ros2cli.node.NodeStrategy consistently. (#173)
    Based on non-backported changes in other packages
- switch to not deprecated API #174
    does not apply to eloquent
- pass argv in add_arguments to add_subparsers_on_demand (#175)
    does not apply to eloquent
- Symlink CA certs instead of copy (#176)
    feature addition
- more verbose test_flake8 error messages (https://github.com/ros2/sros2/commit/b2612f78ff4bec161e54456b5515e1e498474ed3)
    tests related, based on new-API
- use test_msgs instead of std message packages (#181)
    test related
- Add GitHub actions for linting and source-build CI (#178)
    CI, irrelevant for eloquent branch
- Fix file paths for codecov.io (#185)
    CI, irrelevant for eloquent branch
- Use Contexts #177
    new feature, freaking API
- api: reorganize keystore API #188
    refactor: breaking API
- api: reorganize policy API #190
    refactor: breaking API
- api: reorganize permission API #191
    refactor: breaking API
- api: reorganize key API #192
    refactor: breaking API
- api: reorganize artifact generation API #195
    refactor: breaking API
- permission api: use _keystore.get_* functions #194
    refactor: breaking API
- api: reorganize policy generation API #196
    refactor: breaking API
- remove distribute_key verb #197
    breaking API
- security-context -> enclave #198
    does not apply to eloquent
- Update security environment variables #200
    breaking user facing API / variables
- update basic tutorials for foxy #201
    irrelevant for eloquent
- Update generate_policy verb for enclaves #203
    irrelevant for eloquent
- permission signing should use permissions_ca #204
    based on non-backported feature
- Use matching validity dates for cert and permissions #205
    changing template API
- reenable test_generate_policy_no_policy_file #206
    test
- remove function leftover from old generation strategy #207
    breaking API
- start valid date a day before to account for timezone mismatch #209
    follow-up of non-backported change
- use nightly image including all 3 RMWs #215
    CI
- reenable test_security on master builds #208
    CI
- link to jobs instead of badge #218
    only relevant on master
- [tutorial] fix copy-n-paste error on enclave path #220
    irrelevant for eloquent




