### PR TITLE
Add pytest.ini so local tests don't display warning

### DIFF
--- a/sros2/pytest.ini
+++ b/sros2/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

See https://github.com/ros2/ros2/issues/951 for more details and CI.