### PR TITLE
Remove the use of pkg_resources.

### DIFF
--- a/sros2/sros2/policy/__init__.py
+++ b/sros2/sros2/policy/__init__.py
@@ -16,45 +16,47 @@ import os
 
 from lxml import etree
 
-import pkg_resources
+try:
+    import importlib.resources as importlib_resources
+except ModuleNotFoundError:
+    # (clalancette): We have to ignore the type, otherwise mypy throws a warning.
+    # See https://github.com/python/mypy/issues/1153 for details.
+    import importlib_resources  # type: ignore
 
 POLICY_VERSION = '0.2.0'
 
 
 def get_policy_default(name):
-    return pkg_resources.resource_filename(
-        package_or_requirement='sros2',
-        resource_name=os.path.join('policy', 'defaults', name))
+    with importlib_resources.path('sros2.policy.defaults', name) as path:
+        return str(path)
 
 
 def get_policy_schema(name):
-    return pkg_resources.resource_filename(
-        package_or_requirement='sros2',
-        resource_name=os.path.join('policy', 'schemas', name))
+    with importlib_resources.path('sros2.policy.schemas', name) as path:
+        return str(path)
 
 
 def get_policy_template(name):
-    return pkg_resources.resource_filename(
-        package_or_requirement='sros2',
-        resource_name=os.path.join('policy', 'templates', name))
+    with importlib_resources.path('sros2.policy.templates', name) as path:
+        return str(path)
 
 
 def get_transport_default(transport, name):
-    return pkg_resources.resource_filename(
-        package_or_requirement='sros2',
-        resource_name=os.path.join('policy', 'defaults', transport, name))
+    module = 'sros2.policy.defaults.' + transport
+    with importlib_resources.path(module, name) as path:
+        return str(path)
 
 
 def get_transport_schema(transport, name):
-    return pkg_resources.resource_filename(
-        package_or_requirement='sros2',
-        resource_name=os.path.join('policy', 'schemas', transport, name))
+    module = 'sros2.policy.schemas.' + transport
+    with importlib_resources.path(module, name) as path:
+        return str(path)
 
 
 def get_transport_template(transport, name):
-    return pkg_resources.resource_filename(
-        package_or_requirement='sros2',
-        resource_name=os.path.join('policy', 'templates', transport, name))
+    module = 'sros2.policy.templates.' + transport
+    with importlib_resources.path(module, name) as path:
+        return str(path)
 
 
 def load_policy(policy_file_path):

--- a/sros2/sros2/policy/__init__.py
+++ b/sros2/sros2/policy/__init__.py
@@ -19,7 +19,8 @@ from lxml import etree
 try:
     import importlib.resources as importlib_resources
 except ModuleNotFoundError:
-    # (clalancette): We have to ignore the type, otherwise mypy throws a warning.
+    # (clalancette): This fallback is necessary when importlib-resources is installed from pip.
+    # Note that we have to ignore the type, otherwise mypy throws a warning.
     # See https://github.com/python/mypy/issues/1153 for details.
     import importlib_resources  # type: ignore
 

--- a/sros2/sros2/policy/defaults/__init__.py
+++ b/sros2/sros2/policy/defaults/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Workaround to make importlib.resources path lookup work.
+
+importlib.resources in Python 3.8 and earlier doesn't support looking up paths
+in subdirectories.  However, it does support looking up paths in python modules,
+so we add this __init__.py to make this subdirectoy a module.  This workaround
+can be removed when all of the target platforms support Python 3.9 and later;
+see https://gitlab.com/python-devs/importlib_resources/issues/58 for details.
+"""

--- a/sros2/sros2/policy/defaults/dds/__init__.py
+++ b/sros2/sros2/policy/defaults/dds/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Workaround to make importlib.resources path lookup work.
+
+importlib.resources in Python 3.8 and earlier doesn't support looking up paths
+in subdirectories.  However, it does support looking up paths in python modules,
+so we add this __init__.py to make this subdirectoy a module.  This workaround
+can be removed when all of the target platforms support Python 3.9 and later;
+see https://gitlab.com/python-devs/importlib_resources/issues/58 for details.
+"""

--- a/sros2/sros2/policy/schemas/__init__.py
+++ b/sros2/sros2/policy/schemas/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Workaround to make importlib.resources path lookup work.
+
+importlib.resources in Python 3.8 and earlier doesn't support looking up paths
+in subdirectories.  However, it does support looking up paths in python modules,
+so we add this __init__.py to make this subdirectoy a module.  This workaround
+can be removed when all of the target platforms support Python 3.9 and later;
+see https://gitlab.com/python-devs/importlib_resources/issues/58 for details.
+"""

--- a/sros2/sros2/policy/schemas/dds/__init__.py
+++ b/sros2/sros2/policy/schemas/dds/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Workaround to make importlib.resources path lookup work.
+
+importlib.resources in Python 3.8 and earlier doesn't support looking up paths
+in subdirectories.  However, it does support looking up paths in python modules,
+so we add this __init__.py to make this subdirectoy a module.  This workaround
+can be removed when all of the target platforms support Python 3.9 and later;
+see https://gitlab.com/python-devs/importlib_resources/issues/58 for details.
+"""

--- a/sros2/sros2/policy/templates/__init__.py
+++ b/sros2/sros2/policy/templates/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Workaround to make importlib.resources path lookup work.
+
+importlib.resources in Python 3.8 and earlier doesn't support looking up paths
+in subdirectories.  However, it does support looking up paths in python modules,
+so we add this __init__.py to make this subdirectoy a module.  This workaround
+can be removed when all of the target platforms support Python 3.9 and later;
+see https://gitlab.com/python-devs/importlib_resources/issues/58 for details.
+"""

--- a/sros2/sros2/policy/templates/dds/__init__.py
+++ b/sros2/sros2/policy/templates/dds/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Workaround to make importlib.resources path lookup work.
+
+importlib.resources in Python 3.8 and earlier doesn't support looking up paths
+in subdirectories.  However, it does support looking up paths in python modules,
+so we add this __init__.py to make this subdirectoy a module.  This workaround
+can be removed when all of the target platforms support Python 3.9 and later;
+see https://gitlab.com/python-devs/importlib_resources/issues/58 for details.
+"""


### PR DESCRIPTION
Importing pkg_resources is slow; really slow.  pkg_resources
is also somewhat deprecated.  For both of these reaons, we
would prefer to move away from pkg_resources and start using
importlib instead.

sros2 was using 'resource_filename' from pkg_resources.  The
equivalent in importlib is importlib.resources, but there is a catch.
As of Python 3.8, importlib.resources does not support getting
data from subdirectories.  The workaround is to make each
level of the directory structure a python module, so that the
module name can be looked up.  Python 3.9 will have support for
directories for resources, but that won't help on Ubuntu Focal.
More information is in https://gitlab.com/python-devs/importlib_resources/issues/58

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

See ros2/ros2#919 for a lot more details on why we want to do this.