### PR TITLE
Add scope parameter to conftest.py

### DIFF
--- a/sros2/test/conftest.py
+++ b/sros2/test/conftest.py
@@ -22,6 +22,6 @@ import pytest
 os.environ['HTTP_PROXY'] = 'http://example.com'
 
 
-@pytest.fixture('session')
+@pytest.fixture(scope='session')
 def test_policy_dir():
     return pathlib.Path(__file__).parent / 'policies'


### PR DESCRIPTION
Following upstream instructions https://docs.pytest.org/en/stable/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session . Fix #229 

**Testing:**
 * Linux [![Build Status](https://ci.ros2.org/job/ci_linux/11704/badge/icon)](https://ci.ros2.org/job/ci_linux/11704/)
 * Aarch64 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6801)](https://ci.ros2.org/job/ci_linux-aarch64/6801/)
 * Win [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11654)](https://ci.ros2.org/job/ci_windows/11654/)
 * OsX [![Build Status](https://ci.ros2.org/job/ci_osx/9555/badge/icon)](https://ci.ros2.org/job/ci_osx/9555/)