### PR TITLE
Skip the mypy testing on CentOS 7.

### DIFF
--- a/sros2/test/test_mypy.py
+++ b/sros2/test/test_mypy.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from ament_mypy.main import main
 import pytest
 
@@ -19,4 +21,23 @@ import pytest
 @pytest.mark.mypy
 @pytest.mark.linter
 def test_mypy():
+    distroname = ''
+    if os.path.exists('/etc/os-release'):
+        with open('/etc/os-release', 'r') as infp:
+            for line in infp:
+                if line.startswith('ID='):
+                    split = line.strip().split('=')
+                    if len(split) == 2:
+                        distroname = split[1].lstrip('"').rstrip('"')
+                    break
+
+    if distroname == 'centos':
+        # CentOS 7 uses a pip installation of importlib_resources to get access
+        # to the importlib_resources API.  Due to a bug
+        # (https://github.com/python/mypy/issues/1153), mypy cannot determine
+        # the API in that case and so throws a warning.  If we see we are on
+        # CentOS, skip the mypy checking; on all other platforms, run the
+        # test as usual.
+        pytest.skip('CentOS 7 does not support mypy checking of importlib properly')
+
     assert main(argv=[]) == 0, 'Found errors'

--- a/sros2/test/test_mypy.py
+++ b/sros2/test/test_mypy.py
@@ -22,6 +22,7 @@ import pytest
 @pytest.mark.linter
 def test_mypy():
     distroname = ''
+    distroversion = ''
     if os.path.exists('/etc/os-release'):
         with open('/etc/os-release', 'r') as infp:
             for line in infp:
@@ -29,9 +30,15 @@ def test_mypy():
                     split = line.strip().split('=')
                     if len(split) == 2:
                         distroname = split[1].lstrip('"').rstrip('"')
+                elif line.startswith('VERSION_ID='):
+                    split = line.strip().split('=')
+                    if len(split) == 2:
+                        distroversion = split[1].lstrip('"').rstrip('"')
+
+                if distroname != '' and distroversion != '':
                     break
 
-    if distroname == 'centos':
+    if distroname == 'centos' and distroversion == '7':
         # CentOS 7 uses a pip installation of importlib_resources to get access
         # to the importlib_resources API.  Due to a bug
         # (https://github.com/python/mypy/issues/1153), mypy cannot determine


### PR DESCRIPTION
The inline comment has a lot more details on why we need to
do this.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix up the last of the lingering errors on the CentOS job: https://ci.ros2.org/view/nightly/job/nightly_linux-centos_debug/611/

I'll run CI on this once I get agreement that this is the right way to go.