### PR TITLE
[ci] Fix infrastructure issues on test_latest job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test_latest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # 'osrf/ros2:devel' does *not* include RTI Connext or its' security plugins
     # the former gets installed via rosdep in 'action-ros-ci' but the latter do *not* get installed
     container: osrf/ros2:devel
@@ -41,7 +41,7 @@ jobs:
         name: colcon-logs
         path: ros_ws/log
   test_nightly:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # 'osrf/ros2:nightly-rmw-nonfree' includes RTI Connext but
     # does *not* include the security plugins or a license allowing the use of Security
     container: osrf/ros2:nightly-rmw-nonfree

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         apt-get -qq update
         apt-get -qq upgrade -y
-        apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev
+        apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev python3-colcon-coveragepy-result
     - uses: ros-tooling/action-ros-ci@v0.1
       with:
         package-name: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,15 @@ jobs:
       run: |
         apt-get -qq update
         apt-get -qq upgrade -y
-        apt-get -qq install -y curl libasio-dev libtinyxml2-dev
-    # TODO(mikaelarguedas) switch back to ros-tooling/action-ros-ci once
-    # https://github.com/ros-tooling/action-ros-ci/pull/109 is released
-    - uses: mikaelarguedas/action-ros-ci@sros2-version
+        apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev
+    - uses: ros-tooling/action-ros-ci@0.1.0
       with:
         package-name: |
           sros2
           sros2_cmake
           test_security
         extra-cmake-args: '-DSECURITY=ON --no-warn-unused-cli'
+        target-ros2-distro: rolling
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         apt-get -qq update
         apt-get -qq upgrade -y
         apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev
-    - uses: ros-tooling/action-ros-ci@0.1.0
+    - uses: ros-tooling/action-ros-ci@v0.1
       with:
         package-name: |
           sros2


### PR DESCRIPTION
This moves back to using upstream `action-ros-ci`, this will bring us new features and mostly stop using deprecated github actions features.
Also pins down the host platform to ubuntu-20.04 to silence github actions warning

This will not have an impact on flaky tests