### PR TITLE
skip mypy test on centos 7 (alternative)

### DIFF
--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -22,6 +22,7 @@
   <test_depend>ament_mypy</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-rospkg-modules</test_depend>
   <!-- Single entrypoint to depend on launch based testing -->
   <test_depend>ros_testing</test_depend>
   <test_depend>test_msgs</test_depend>

--- a/sros2/test/test_mypy.py
+++ b/sros2/test/test_mypy.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Canonical Ltd
+# Copyright 2020 Mikael Arguedas
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +15,20 @@
 
 from ament_mypy.main import main
 import pytest
+from rospkg.os_detect import read_os_release
 
 
 @pytest.mark.mypy
 @pytest.mark.linter
 def test_mypy():
+    release_info = read_os_release()
+    if isinstance(release_info, dict) and all(key in release_info for key in ['ID', 'VERSION_ID']):
+        if release_info['ID'] == 'centos' and release_info['VERSION_ID'] == '7':
+            # CentOS 7 uses a pip installation of importlib_resources to get access
+            # to the importlib_resources API.  Due to a bug
+            # (https://github.com/python/mypy/issues/1153), mypy cannot determine
+            # the API in that case and so throws a warning.  If we see we are on
+            # CentOS, skip the mypy checking; on all other platforms, run the
+            # test as usual.
+            pytest.skip('CentOS 7 does not support mypy checking of importlib properly')
     assert main(argv=[]) == 0, 'Found errors'


### PR DESCRIPTION
Replaces https://github.com/ros2/sros2/pull/246 and uses rospkg to avoid duplicating os-release parsing logic.