### PR TITLE
Declare missing dependency on python3-importlib-resources

### DIFF
--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -16,11 +16,13 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-lxml</exec_depend>
   <exec_depend>python3-cryptography</exec_depend>
+  <exec_depend>python3-importlib-resources</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_mypy</test_depend>
   <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-importlib-resources</test_depend>
   <test_depend>python3-pytest</test_depend>
   <!-- Single entrypoint to depend on launch based testing -->
   <test_depend>ros_testing</test_depend>

--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -22,7 +22,6 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_mypy</test_depend>
   <test_depend>ament_pep257</test_depend>
-  <test_depend>python3-importlib-resources</test_depend>
   <test_depend>python3-pytest</test_depend>
   <!-- Single entrypoint to depend on launch based testing -->
   <test_depend>ros_testing</test_depend>


### PR DESCRIPTION
Requires ros/rosdistro#28001.

Used here:
https://github.com/ros2/sros2/blob/74da58f7433833562226f1cf05113229cee11005/sros2/sros2/policy/__init__.py#L19-L25

The source code supports using the `importlib_resources` package, but on all of the platforms we're running regular builds for, we have ~~Python 3.7~~ Python 3.9, which provides the package as part of Python itself.