### PR TITLE
Fix namedtuple names.

### DIFF
--- a/sros2/sros2/verb/generate_policy.py
+++ b/sros2/sros2/verb/generate_policy.py
@@ -43,8 +43,8 @@ from sros2.verb import VerbExtension
 
 _HIDDEN_NODE_PREFIX = '_'
 
-_NodeName = namedtuple('NodeName', ('node', 'ns', 'fqn', 'path'))
-_TopicInfo = namedtuple('Topic', ('fqn', 'type'))
+_NodeName = namedtuple('_NodeName', ('node', 'ns', 'fqn', 'path'))
+_TopicInfo = namedtuple('_TopicInfo', ('fqn', 'type'))
 
 
 class GeneratePolicyVerb(VerbExtension):


### PR DESCRIPTION
According to the documentation for namedtuple:

"To support pickling, the named tuple class should be assigned to a variable that matches typename."

The newest version of mypy (0.800) now has a warning for this
as well.  Change the name that is the first argument to
eliminate this warning.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>