### PR TITLE
Skip mypy test on platforms using importlib_resources

### DIFF
--- a/sros2/test/test_mypy.py
+++ b/sros2/test/test_mypy.py
@@ -19,4 +19,13 @@ import pytest
 @pytest.mark.mypy
 @pytest.mark.linter
 def test_mypy():
+    try:
+        import importlib.resources as _  # noqa: F401
+    except ModuleNotFoundError:
+        # The importlib_resources package is a backport of the importlib.resources module
+        # from Python 3.9. The 'policy' module of this project first tries to import from
+        # importlib.resources, then falls back to the backport package.
+        # There is a bug in mypy that manifests when this try/except import pattern is
+        # used: https://github.com/python/mypy/issues/1153
+        pytest.skip('This platform does not support mypy checking of importlib properly')
     assert main(argv=[]) == 0, 'Found errors'


### PR DESCRIPTION
Platform-agnostic alternative to #248

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14334)](http://ci.ros2.org/job/ci_linux/14334/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9118)](http://ci.ros2.org/job/ci_linux-aarch64/9118/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=122)](http://ci.ros2.org/job/ci_linux-rhel/122/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12017)](http://ci.ros2.org/job/ci_osx/12017/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14436)](http://ci.ros2.org/job/ci_windows/14436/)