### PR TITLE
Wait for node discovery in test_generate_policy.

### DIFF
--- a/sros2/test/sros2/commands/security/verbs/test_generate_policy.py
+++ b/sros2/test/sros2/commands/security/verbs/test_generate_policy.py
@@ -104,12 +104,17 @@ class TestSROS2GeneratePolicyVerb(SROS2CLITestCase):
         self,
         pub_sub_node_name,
         pub_sub_node_namespace,
-        pub_sub_node_enclave
+        pub_sub_node_enclave,
+        use_daemon
     ):
-        assert self.wait_for(expected_topics=[
-            expand_topic_name('~/pub', pub_sub_node_name, pub_sub_node_namespace),
-            expand_topic_name('~/sub', pub_sub_node_name, pub_sub_node_namespace),
-        ])
+        if use_daemon:
+            assert self.wait_for(
+                expected_nodes=[pub_sub_node_namespace + '/' + pub_sub_node_name],
+                expected_topics=[
+                    expand_topic_name('~/pub', pub_sub_node_name, pub_sub_node_namespace),
+                    expand_topic_name('~/sub', pub_sub_node_name, pub_sub_node_namespace),
+                ]
+            )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             test_policy = pathlib.Path(tmpdir).joinpath('test-policy.xml')
@@ -146,12 +151,17 @@ class TestSROS2GeneratePolicyVerb(SROS2CLITestCase):
         self,
         client_srv_node_name,
         client_srv_node_namespace,
-        client_srv_node_enclave
+        client_srv_node_enclave,
+        use_daemon
     ):
-        assert self.wait_for(expected_services=[
-            expand_topic_name('~/client', client_srv_node_name, client_srv_node_namespace),
-            expand_topic_name('~/server', client_srv_node_name, client_srv_node_namespace),
-        ])
+        if use_daemon:
+            assert self.wait_for(
+                expected_nodes=[client_srv_node_namespace + '/' + client_srv_node_name],
+                expected_services=[
+                    expand_topic_name('~/client', client_srv_node_name, client_srv_node_namespace),
+                    expand_topic_name('~/server', client_srv_node_name, client_srv_node_namespace),
+                ]
+            )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             test_policy = pathlib.Path(tmpdir).joinpath('test-policy.xml')


### PR DESCRIPTION
Replacement for #260. Only wait when daemon is in use (if not, CLI will use a different node).

CI up to `sros2`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14379)](http://ci.ros2.org/job/ci_linux/14379/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9154)](http://ci.ros2.org/job/ci_linux-aarch64/9154/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12055)](http://ci.ros2.org/job/ci_osx/12055/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14478)](http://ci.ros2.org/job/ci_windows/14478/)
