### PR TITLE
Enable document generation using rosdoc2 for ament_python pkgs

### DIFF
--- a/sros2/sros2/__init__.py
+++ b/sros2/sros2/__init__.py
@@ -23,7 +23,7 @@ _xml_cache_path = urllib.parse.urljoin(
     'file:',
     urllib.request.pathname2url(
         os.path.join(
-            ament_index_python.get_package_share_directory('sros2'),
+            str(ament_index_python.get_package_share_directory('sros2')),
             'xml_cache',
             'xhtml-cache.xml'
         )


### PR DESCRIPTION
Make type of `ament_index_python.get_package_share_directory()` explicit for autodoc to generate documentation since it does not import dep modules.