### PR TITLE
Fix a number of warnings on Ubuntu 24.04.

### DIFF
--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -10,13 +10,13 @@
   <author email="morgan@osrfoundation.org">Morgan Quigley</author>
   <author>Mikael Arguedas</author>
 
-  <depend>rclpy</depend>
-  <depend>ros2cli</depend>
-
   <exec_depend>ament_index_python</exec_depend>
-  <exec_depend>python3-lxml</exec_depend>
+  <exec_depend>python3-argcomplete</exec_depend>
   <exec_depend>python3-cryptography</exec_depend>
   <exec_depend>python3-importlib-resources</exec_depend>
+  <exec_depend>python3-lxml</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/sros2/sros2/api/_artifact_generation.py
+++ b/sros2/sros2/api/_artifact_generation.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pathlib
-from typing import List
+from typing import List, Optional
 
 from sros2 import _utilities, keystore
 from sros2.policy import load_policy
@@ -22,7 +22,7 @@ from . import _policy
 
 
 def generate_artifacts(
-        keystore_path: pathlib.Path = None,
+        keystore_path: Optional[pathlib.Path] = None,
         identity_names: List[str] = [],
         policy_files: List[pathlib.Path] = []) -> None:
     if keystore_path is None:

--- a/sros2/sros2/policy/__init__.py
+++ b/sros2/sros2/policy/__init__.py
@@ -27,37 +27,39 @@ except ModuleNotFoundError:
 POLICY_VERSION = '0.2.0'
 
 
+def _get_path(template, name):
+    if hasattr(importlib_resources, 'files'):
+        return importlib_resources.files(template).joinpath(name)
+    else:
+        with importlib_resources.path(template, name) as path:
+            return str(path)
+
+
 def get_policy_default(name: str) -> pathlib.Path:
-    with importlib_resources.path('sros2.policy.defaults', name) as path:
-        return path
+    return _get_path('sros2.policy.defaults', name)
 
 
 def get_policy_schema(name: str) -> pathlib.Path:
-    with importlib_resources.path('sros2.policy.schemas', name) as path:
-        return path
+    return _get_path('sros2.policy.schemas', name)
 
 
 def get_policy_template(name: str) -> pathlib.Path:
-    with importlib_resources.path('sros2.policy.templates', name) as path:
-        return path
+    return _get_path('sros2.policy.templates', name)
 
 
 def get_transport_default(transport: str, name: str) -> pathlib.Path:
     module = 'sros2.policy.defaults.' + transport
-    with importlib_resources.path(module, name) as path:
-        return path
+    return _get_path(module, name)
 
 
 def get_transport_schema(transport: str, name: str) -> pathlib.Path:
     module = 'sros2.policy.schemas.' + transport
-    with importlib_resources.path(module, name) as path:
-        return path
+    return _get_path(module, name)
 
 
 def get_transport_template(transport: str, name: str) -> pathlib.Path:
     module = 'sros2.policy.templates.' + transport
-    with importlib_resources.path(module, name) as path:
-        return path
+    return _get_path(module, name)
 
 
 def load_policy(policy_file_path: pathlib.Path) -> etree.ElementTree:

--- a/sros2/sros2/policy/__init__.py
+++ b/sros2/sros2/policy/__init__.py
@@ -32,7 +32,7 @@ def _get_path(template, name):
         return importlib_resources.files(template).joinpath(name)
     else:
         with importlib_resources.path(template, name) as path:
-            return str(path)
+            return path
 
 
 def get_policy_default(name: str) -> pathlib.Path:

--- a/sros2/sros2/verb/create_enclave.py
+++ b/sros2/sros2/verb/create_enclave.py
@@ -16,11 +16,7 @@ import pathlib
 import sys
 import warnings
 
-try:
-    from argcomplete.completers import DirectoriesCompleter
-except ImportError:
-    def DirectoriesCompleter():
-        return None
+from argcomplete.completers import DirectoriesCompleter
 
 import sros2.keystore
 from sros2.verb import VerbExtension

--- a/sros2/sros2/verb/create_keystore.py
+++ b/sros2/sros2/verb/create_keystore.py
@@ -15,11 +15,7 @@
 import pathlib
 import sys
 
-try:
-    from argcomplete.completers import DirectoriesCompleter
-except ImportError:
-    def DirectoriesCompleter():
-        return None
+from argcomplete.completers import DirectoriesCompleter
 
 import sros2.errors
 import sros2.keystore

--- a/sros2/sros2/verb/create_permission.py
+++ b/sros2/sros2/verb/create_permission.py
@@ -15,16 +15,8 @@
 import pathlib
 import sys
 
-try:
-    from argcomplete.completers import DirectoriesCompleter
-except ImportError:
-    def DirectoriesCompleter():
-        return None
-try:
-    from argcomplete.completers import FilesCompleter
-except ImportError:
-    def FilesCompleter(*, allowednames, directories):
-        return None
+from argcomplete.completers import DirectoriesCompleter
+from argcomplete.completers import FilesCompleter
 
 import sros2.keystore
 from sros2.verb import VerbExtension

--- a/sros2/sros2/verb/generate_artifacts.py
+++ b/sros2/sros2/verb/generate_artifacts.py
@@ -15,16 +15,8 @@
 import pathlib
 import sys
 
-try:
-    from argcomplete.completers import DirectoriesCompleter
-except ImportError:
-    def DirectoriesCompleter():
-        return None
-try:
-    from argcomplete.completers import FilesCompleter
-except ImportError:
-    def FilesCompleter(*, allowednames, directories):
-        return None
+from argcomplete.completers import DirectoriesCompleter
+from argcomplete.completers import FilesCompleter
 
 from sros2.api import _artifact_generation
 import sros2.errors

--- a/sros2/sros2/verb/generate_policy.py
+++ b/sros2/sros2/verb/generate_policy.py
@@ -16,16 +16,7 @@ from collections import namedtuple
 import pathlib
 import sys
 
-try:
-    from argcomplete.completers import DirectoriesCompleter
-except ImportError:
-    def DirectoriesCompleter():
-        return None
-try:
-    from argcomplete.completers import FilesCompleter
-except ImportError:
-    def FilesCompleter(*, allowednames, directories):
-        return None
+from argcomplete.completers import FilesCompleter
 
 from lxml import etree
 

--- a/sros2/sros2/verb/list_enclaves.py
+++ b/sros2/sros2/verb/list_enclaves.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from argcomplete.completers import DirectoriesCompleter
-except ImportError:
-    def DirectoriesCompleter():
-        return None
-
 import pathlib
 import sys
 import warnings
+
+from argcomplete.completers import DirectoriesCompleter
 
 import sros2.keystore
 from sros2.verb import VerbExtension


### PR DESCRIPTION
In particular:
1.  Get rid of the fallback path for argcompleter.  It isn't necessary anymore since all versions of argcompleter support these, and it was confusing mypy.
2.  Add in a proper Optional annotation.
3.  Use the newer importlib_resources.file API when it is available.