### PR TITLE
Use modern PKCS7 to sign the certificate bytes.

### DIFF
--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -19,10 +19,10 @@ import pathlib
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend as cryptography_backend
-from cryptography.hazmat.bindings.openssl.binding import Binding as SSLBinding
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import pkcs7
 
 import sros2.errors
 
@@ -134,39 +134,10 @@ def load_cert(cert_path: pathlib.Path):
 
 
 def _sign_bytes(cert, key, byte_string):
-    # Using two flags here to get the output required:
-    #   - PKCS7_DETACHED: Use cleartext signing
-    #   - PKCS7_TEXT: Set the MIME headers for text/plain
-    flags = SSLBinding.lib.PKCS7_DETACHED
-    flags |= SSLBinding.lib.PKCS7_TEXT
-
-    # Convert the byte string into a buffer for SSL
-    bio_in = SSLBinding.lib.BIO_new_mem_buf(byte_string, len(byte_string))
-    try:
-        pkcs7 = SSLBinding.lib.PKCS7_sign(
-            cert._x509, key._evp_pkey, SSLBinding.ffi.NULL, bio_in, flags)
-    finally:
-        # Free the memory allocated for the buffer
-        SSLBinding.lib.BIO_free(bio_in)
-
-    # PKCS7_sign consumes the buffer; allocate a new one again to get it into the final document
-    bio_in = SSLBinding.lib.BIO_new_mem_buf(byte_string, len(byte_string))
-    try:
-        # Allocate a buffer for the output document
-        bio_out = SSLBinding.lib.BIO_new(SSLBinding.lib.BIO_s_mem())
-        try:
-            # Write the final document out to the buffer
-            SSLBinding.lib.SMIME_write_PKCS7(bio_out, pkcs7, bio_in, flags)
-
-            # Copy the output document back to python-managed memory
-            result_buffer = SSLBinding.ffi.new('char**')
-            buffer_length = SSLBinding.lib.BIO_get_mem_data(bio_out, result_buffer)
-            output = SSLBinding.ffi.buffer(result_buffer[0], buffer_length)[:]
-        finally:
-            # Free the memory required for the output buffer
-            SSLBinding.lib.BIO_free(bio_out)
-    finally:
-        # Free the memory allocated for the input buffer
-        SSLBinding.lib.BIO_free(bio_in)
-
-    return output
+    builder = (
+        pkcs7.PKCS7SignatureBuilder()
+        .set_data(byte_string)
+        .add_signer(cert, key, hashes.SHA256())
+    )
+    options = [pkcs7.PKCS7Options.Text, pkcs7.PKCS7Options.DetachedSignature]
+    return builder.sign(serialization.Encoding.SMIME, options)


### PR DESCRIPTION
Using the SSLBinding leads to a warning in newer versions of pycryptography.  Luckily, there is a supported API called pkcs7 that allows us to do the same thing.  Even better, this API is supported since pycryptography 3.2, so this should work on both Ubuntu 22.04 and Ubuntu 24.04 without warnings.