### PR TITLE
Fix linux tutorial: cloning example policies and set of default policies for a node

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This package provides the tools and instructions to use ROS2 on top of DDS-Security.
 The security feature is tested across platforms (Linux, macOS, and Windows) as well as across different languages (C++ and Python).
 
-Although we are designing SROS2 to work with any secure middleware, at the moment we are testing with RTI Connext Secure 5.3.1 and eProsima's Fast-RTPS 1.6.0.
+This package has been tested against eProsima FastDDS, Eclipse CycloneDDS and RTI Connext.
 If you want to run the demo using RTI Connext Secure you will need a license for it and you will need to install it.
 
 These Tutorials are written for the latest state of the repository.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![SROS2 CI](https://github.com/ros2/sros2/workflows/SROS2%20CI/badge.svg)](https://github.com/ros2/sros2/actions?query=workflow%3A%22SROS2+CI%22+branch%3Amaster)
 [![codecov](https://codecov.io/gh/ros2/sros2/branch/master/graph/badge.svg)](https://codecov.io/gh/ros2/sros2)
 
-This package provides the tools and instructions to use ROS2 on top of DDS-Security.
+This package provides the tools and instructions to use ROS 2 on top of DDS-Security.
 The security feature is tested across platforms (Linux, macOS, and Windows) as well as across different languages (C++ and Python).
 
 This package has been tested against eProsima FastDDS, Eclipse CycloneDDS and RTI Connext.

--- a/SROS2_Linux.md
+++ b/SROS2_Linux.md
@@ -86,12 +86,11 @@ These variables need to be defined in each terminal used for the demo. For conve
 ### Run the demo
 
 ROS2 allows you to [change DDS implementation at runtime](https://docs.ros.org/en/rolling/Guides/Working-with-multiple-RMW-implementations.html).
-This demo can be run with fastrtps by setting:
+This demo can be run with FastDDS / CycloneDDS / ConnextDDS by setting the `RMW_IMPLEMENTATION` variable, e.g.:
+
 ```bash
-export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-```
-And with Connext by setting:
-```bash
+export RMW_IMPLEMENTATION=rmw_fastrtps_cpp  # or
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp  # or
 export RMW_IMPLEMENTATION=rmw_connextdds
 ```
 

--- a/SROS2_Linux.md
+++ b/SROS2_Linux.md
@@ -85,7 +85,7 @@ These variables need to be defined in each terminal used for the demo. For conve
 
 ### Run the demo
 
-ROS2 allows you to [change DDS implementation at runtime](https://docs.ros.org/en/rolling/Guides/Working-with-multiple-RMW-implementations.html).
+ROS 2 allows you to [change DDS implementation at runtime](https://docs.ros.org/en/rolling/Guides/Working-with-multiple-RMW-implementations.html).
 This demo can be run with FastDDS / CycloneDDS / ConnextDDS by setting the `RMW_IMPLEMENTATION` variable, e.g.:
 
 ```bash

--- a/SROS2_Linux.md
+++ b/SROS2_Linux.md
@@ -166,16 +166,16 @@ To do this, we will use the sample policy file provided in `examples/sample_poli
 First, we will copy this sample policy file into our keystore:
 
 ```bash
-sudo apt update && sudo apt install subversion
+sudo apt update && sudo apt install git
 cd ~/sros2_demo
-svn checkout https://github.com/ros2/sros2/trunk/sros2/test/policies
+git clone https://github.com/ros2/sros2.git /tmp/sros2
 ```
 
 And now we will use it to generate the XML permission files expected by the middleware:
 
 ```bash
-ros2 security create_permission demo_keystore /talker_listener/talker policies/sample.policy.xml
-ros2 security create_permission demo_keystore /talker_listener/listener policies/sample.policy.xml
+ros2 security create_permission demo_keystore /talker_listener/talker /tmp/sros2/sros2/test/policies/sample.policy.xml
+ros2 security create_permission demo_keystore /talker_listener/listener /tmp/sros2/sros2/test/policies/sample.policy.xml
 ```
 
 These permission files will be stricter than the ones that were used in the previous demo: the nodes will only be allowed to publish or subscribe to the `chatter` topic (and some other topics used for parameters).

--- a/SROS2_Linux.md
+++ b/SROS2_Linux.md
@@ -115,6 +115,38 @@ Note: You can switch between the C++ (demo_nodes_cpp) and Python (demo_nodes_py)
 
 These nodes are able to communicate because we have created the appropriate keys and certificates for them.
 
+To be able to use the ros2 CLI tools to interact with your secured system, you need to provide it with an override enclave:
+```bash
+export ROS_SECURITY_ENCLAVE_OVERRIDE=/talker_listener/listener
+```
+
+Then use the CLI as usual:
+
+```bash
+ros2 node list
+```
+```
+/talker
+```
+```bash
+ros2 topic list
+```
+```
+/chatter
+/parameter_events
+/rosout
+```
+```bash
+ros2 topic echo /chatter
+```
+```
+[INFO] [1714897092.882384995] [rcl]: Found security directory: /root/sros2_demo/demo_keystore/enclaves/talker_listener/listener
+data: 'Hello World: 257'
+---
+data: 'Hello World: 258'
+---
+
+```
 
 ### Run the demo on different machines
 

--- a/SROS2_MacOS.md
+++ b/SROS2_MacOS.md
@@ -94,7 +94,7 @@ These variables need to be defined in each terminal used for the demo. For conve
 
 ## Run the demo
 
-ROS2 allows you to [change DDS implementation at runtime](https://docs.ros.org/en/rolling/Guides/Working-with-multiple-RMW-implementations.html).
+ROS 2 allows you to [change DDS implementation at runtime](https://docs.ros.org/en/rolling/Guides/Working-with-multiple-RMW-implementations.html).
 This demo can be run with FastDDS / CycloneDDS / ConnextDDS by setting the `RMW_IMPLEMENTATION` variable, e.g.:
 
 ```bash

--- a/SROS2_MacOS.md
+++ b/SROS2_MacOS.md
@@ -90,17 +90,16 @@ export ROS_SECURITY_ENABLE=true
 export ROS_SECURITY_STRATEGY=Enforce
 ```
 
-These variables need to be defined in each terminal used for the demo. For convenience you can add it to your bash_profile.
+These variables need to be defined in each terminal used for the demo. For convenience you can add it to your `bash_profile`.
 
 ## Run the demo
 
 ROS2 allows you to [change DDS implementation at runtime](https://docs.ros.org/en/rolling/Guides/Working-with-multiple-RMW-implementations.html).
-This demo can be run with fastrtps by setting:
+This demo can be run with FastDDS / CycloneDDS / ConnextDDS by setting the `RMW_IMPLEMENTATION` variable, e.g.:
+
 ```bash
-export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-```
-And with Connext by setting:
-```bash
+export RMW_IMPLEMENTATION=rmw_fastrtps_cpp  # or
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp  # or
 export RMW_IMPLEMENTATION=rmw_connextdds
 ```
 

--- a/SROS2_MacOS.md
+++ b/SROS2_MacOS.md
@@ -125,6 +125,38 @@ Note: You can switch between the C++ and Python packages arbitrarily.
 
 These nodes are able to communicate because we have created the appropriate keys and certificates for them.
 
+To be able to use the ros2 CLI tools to interact with your secured system, you need to provide it with an override enclave:
+```bash
+export ROS_SECURITY_ENCLAVE_OVERRIDE=/talker_listener/listener
+```
+
+Then use the CLI as usual:
+
+```bash
+ros2 node list
+```
+```
+/talker
+```
+```bash
+ros2 topic list
+```
+```
+/chatter
+/parameter_events
+/rosout
+```
+```bash
+ros2 topic echo /chatter
+```
+```
+[INFO] [1714897092.882384995] [rcl]: Found security directory: /root/sros2_demo/demo_keystore/enclaves/talker_listener/listener
+data: 'Hello World: 257'
+---
+data: 'Hello World: 258'
+---
+
+```
 
 ### Access Control
 

--- a/SROS2_MacOS.md
+++ b/SROS2_MacOS.md
@@ -137,14 +137,14 @@ To do this, we will use the sample policy file provided in `examples/sample_poli
 First, we will copy this sample policy file into our keystore:
 
 ```bash
-svn checkout https://github.com/ros2/sros2/trunk/sros2/test/policies
+git clone https://github.com/ros2/sros2.git /tmp/sros2
 ```
 
 And now we will use it to generate the XML permission files expected by the middleware:
 
 ```bash
-ros2 security create_permission demo_keystore /talker_listener/talker policies/sample.policy.xml
-ros2 security create_permission demo_keystore /talker_listener/listener policies/sample.policy.xml
+ros2 security create_permission demo_keystore /talker_listener/talker /tmp/sros2/sros2/test/policies/sample.policy.xml
+ros2 security create_permission demo_keystore /talker_listener/listener /tmp/sros2/sros2/test/policies/sample.policy.xml
 ```
 
 These permission files will be stricter than the ones that were used in the previous demo: the nodes will only be allowed to publish or subscribe to the `chatter` topic (and some other topics used for parameters).

--- a/SROS2_Windows.md
+++ b/SROS2_Windows.md
@@ -124,6 +124,39 @@ Note: You can switch between the C++ (demo_nodes_cpp) and Python (demo_nodes_py)
 
 These nodes are able to communicate because we have created the appropriate keys and certificates for them.
 
+To be able to use the ros2 CLI tools to interact with your secured system, you need to provide it with an override enclave:
+```bat
+set ROS_SECURITY_ENCLAVE_OVERRIDE=/talker_listener/listener
+```
+
+Then use the CLI as usual:
+
+```bat
+ros2 node list
+```
+```
+/talker
+```
+```bat
+ros2 topic list
+```
+```
+/chatter
+/parameter_events
+/rosout
+```
+```bat
+ros2 topic echo /chatter
+```
+```
+[INFO] [1714897092.882384995] [rcl]: Found security directory: /root/sros2_demo/demo_keystore/enclaves/talker_listener/listener
+data: 'Hello World: 257'
+---
+data: 'Hello World: 258'
+---
+
+```
+
 ### Access Control
 
 The previous demo used authentication and encryption, but not access control, which means that any authenticated node would be able to publish and subscribe to any data stream (aka topic).

--- a/SROS2_Windows.md
+++ b/SROS2_Windows.md
@@ -85,12 +85,11 @@ set ROS_SECURITY_STRATEGY=Enforce
 ## Run the demo
 
 ROS2 allows you to [change DDS implementation at runtime](https://docs.ros.org/en/rolling/Guides/Working-with-multiple-RMW-implementations.html).
-This demo can be run with fastrtps by setting:
+This demo can be run with FastDDS / CycloneDDS / ConnextDDS by setting the `RMW_IMPLEMENTATION` variable, e.g.:
+
 ```bat
-set RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-```
-And with Connext by setting:
-```bat
+set RMW_IMPLEMENTATION=rmw_fastrtps_cpp  # or
+set RMW_IMPLEMENTATION=rmw_cyclonedds_cpp  # or
 set RMW_IMPLEMENTATION=rmw_connextdds
 ```
 

--- a/SROS2_Windows.md
+++ b/SROS2_Windows.md
@@ -84,7 +84,7 @@ set ROS_SECURITY_STRATEGY=Enforce
 
 ## Run the demo
 
-ROS2 allows you to [change DDS implementation at runtime](https://docs.ros.org/en/rolling/Guides/Working-with-multiple-RMW-implementations.html).
+ROS 2 allows you to [change DDS implementation at runtime](https://docs.ros.org/en/rolling/Guides/Working-with-multiple-RMW-implementations.html).
 This demo can be run with FastDDS / CycloneDDS / ConnextDDS by setting the `RMW_IMPLEMENTATION` variable, e.g.:
 
 ```bat

--- a/sros2/test/policies/common/node.xml
+++ b/sros2/test/policies/common/node.xml
@@ -6,4 +6,6 @@
     xpointer="xpointer(/profile/*)"/>
   <xi:include href="node/parameters.xml"
     xpointer="xpointer(/profile/*)"/>
+  <xi:include href="node/types.xml"
+    xpointer="xpointer(/profile/*)"/>
 </profile>

--- a/sros2/test/policies/common/node/types.xml
+++ b/sros2/test/policies/common/node/types.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile>
+  <services reply="ALLOW" request="ALLOW" >
+    <service>~/get_type_description</service>
+  </services>
+</profile>

--- a/sros2/test/policies/permissions/add_two_ints/permissions.xml
+++ b/sros2/test/policies/permissions/add_two_ints/permissions.xml
@@ -18,6 +18,7 @@
             <topic>rq/add_two_ints_server/list_parametersRequest</topic>
             <topic>rq/add_two_ints_server/set_parametersRequest</topic>
             <topic>rq/add_two_ints_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_server/get_type_descriptionRequest</topic>
             <topic>rr/add_two_intsReply</topic>
             <topic>rr/add_two_ints_server/describe_parametersReply</topic>
             <topic>rr/add_two_ints_server/get_parameter_typesReply</topic>
@@ -25,6 +26,7 @@
             <topic>rr/add_two_ints_server/list_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_server/get_type_descriptionReply</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
           </topics>
@@ -70,12 +72,14 @@
             <topic>rq/add_two_ints_client/list_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_client/get_type_descriptionRequest</topic>
             <topic>rr/add_two_ints_client/describe_parametersReply</topic>
             <topic>rr/add_two_ints_client/get_parameter_typesReply</topic>
             <topic>rr/add_two_ints_client/get_parametersReply</topic>
             <topic>rr/add_two_ints_client/list_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_client/get_type_descriptionReply</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
           </topics>
@@ -88,6 +92,7 @@
             <topic>rq/add_two_ints_client/list_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_client/get_type_descriptionRequest</topic>
             <topic>rr/add_two_intsReply</topic>
             <topic>rr/add_two_ints_client/describe_parametersReply</topic>
             <topic>rr/add_two_ints_client/get_parameter_typesReply</topic>
@@ -95,6 +100,7 @@
             <topic>rr/add_two_ints_client/list_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_client/get_type_descriptionReply</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>
           </topics>

--- a/sros2/test/policies/permissions/minimal_action/permissions.xml
+++ b/sros2/test/policies/permissions/minimal_action/permissions.xml
@@ -18,6 +18,7 @@
             <topic>rq/minimal_action_server/list_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_server/get_type_descriptionRequest</topic>
             <topic>rr/fibonacci/_action/cancel_goalReply</topic>
             <topic>rr/fibonacci/_action/get_resultReply</topic>
             <topic>rr/fibonacci/_action/send_goalReply</topic>
@@ -29,6 +30,7 @@
             <topic>rr/minimal_action_server/list_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_server/get_type_descriptionReply</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
           </topics>
@@ -44,12 +46,14 @@
             <topic>rq/minimal_action_server/list_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_server/get_type_descriptionRequest</topic>
             <topic>rr/minimal_action_server/describe_parametersReply</topic>
             <topic>rr/minimal_action_server/get_parameter_typesReply</topic>
             <topic>rr/minimal_action_server/get_parametersReply</topic>
             <topic>rr/minimal_action_server/list_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_server/get_type_descriptionReply</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>
           </topics>
@@ -78,12 +82,14 @@
             <topic>rq/minimal_action_client/list_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_client/get_type_descriptionRequest</topic>
             <topic>rr/minimal_action_client/describe_parametersReply</topic>
             <topic>rr/minimal_action_client/get_parameter_typesReply</topic>
             <topic>rr/minimal_action_client/get_parametersReply</topic>
             <topic>rr/minimal_action_client/list_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_client/get_type_descriptionReply</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
           </topics>
@@ -96,6 +102,7 @@
             <topic>rq/minimal_action_client/list_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_client/get_type_descriptionRequest</topic>
             <topic>rr/fibonacci/_action/cancel_goalReply</topic>
             <topic>rr/fibonacci/_action/get_resultReply</topic>
             <topic>rr/fibonacci/_action/send_goalReply</topic>
@@ -107,6 +114,7 @@
             <topic>rr/minimal_action_client/list_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_client/get_type_descriptionReply</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>
           </topics>

--- a/sros2/test/policies/permissions/sample/permissions.xml
+++ b/sros2/test/policies/permissions/sample/permissions.xml
@@ -18,12 +18,14 @@
             <topic>rq/talker/list_parametersRequest</topic>
             <topic>rq/talker/set_parametersRequest</topic>
             <topic>rq/talker/set_parameters_atomicallyRequest</topic>
+            <topic>rq/talker/get_type_descriptionRequest</topic>
             <topic>rr/talker/describe_parametersReply</topic>
             <topic>rr/talker/get_parameter_typesReply</topic>
             <topic>rr/talker/get_parametersReply</topic>
             <topic>rr/talker/list_parametersReply</topic>
             <topic>rr/talker/set_parametersReply</topic>
             <topic>rr/talker/set_parameters_atomicallyReply</topic>
+            <topic>rr/talker/get_type_descriptionReply</topic>
             <topic>rt/chatter</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
@@ -37,12 +39,14 @@
             <topic>rq/talker/list_parametersRequest</topic>
             <topic>rq/talker/set_parametersRequest</topic>
             <topic>rq/talker/set_parameters_atomicallyRequest</topic>
+            <topic>rq/talker/get_type_descriptionRequest</topic>
             <topic>rr/talker/describe_parametersReply</topic>
             <topic>rr/talker/get_parameter_typesReply</topic>
             <topic>rr/talker/get_parametersReply</topic>
             <topic>rr/talker/list_parametersReply</topic>
             <topic>rr/talker/set_parametersReply</topic>
             <topic>rr/talker/set_parameters_atomicallyReply</topic>
+            <topic>rr/talker/get_type_descriptionReply</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>
           </topics>
@@ -68,12 +72,14 @@
             <topic>rq/listener/list_parametersRequest</topic>
             <topic>rq/listener/set_parametersRequest</topic>
             <topic>rq/listener/set_parameters_atomicallyRequest</topic>
+            <topic>rq/listener/get_type_descriptionRequest</topic>
             <topic>rr/listener/describe_parametersReply</topic>
             <topic>rr/listener/get_parameter_typesReply</topic>
             <topic>rr/listener/get_parametersReply</topic>
             <topic>rr/listener/list_parametersReply</topic>
             <topic>rr/listener/set_parametersReply</topic>
             <topic>rr/listener/set_parameters_atomicallyReply</topic>
+            <topic>rr/listener/get_type_descriptionReply</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
           </topics>
@@ -86,12 +92,14 @@
             <topic>rq/listener/list_parametersRequest</topic>
             <topic>rq/listener/set_parametersRequest</topic>
             <topic>rq/listener/set_parameters_atomicallyRequest</topic>
+            <topic>rq/listener/get_type_descriptionRequest</topic>
             <topic>rr/listener/describe_parametersReply</topic>
             <topic>rr/listener/get_parameter_typesReply</topic>
             <topic>rr/listener/get_parametersReply</topic>
             <topic>rr/listener/list_parametersReply</topic>
             <topic>rr/listener/set_parametersReply</topic>
             <topic>rr/listener/set_parameters_atomicallyReply</topic>
+            <topic>rr/listener/get_type_descriptionReply</topic>
             <topic>rt/chatter</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>
@@ -118,6 +126,7 @@
             <topic>rq/add_two_ints_server/list_parametersRequest</topic>
             <topic>rq/add_two_ints_server/set_parametersRequest</topic>
             <topic>rq/add_two_ints_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_server/get_type_descriptionRequest</topic>
             <topic>rr/add_two_intsReply</topic>
             <topic>rr/add_two_ints_server/describe_parametersReply</topic>
             <topic>rr/add_two_ints_server/get_parameter_typesReply</topic>
@@ -125,6 +134,7 @@
             <topic>rr/add_two_ints_server/list_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_server/get_type_descriptionReply</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
           </topics>
@@ -138,12 +148,14 @@
             <topic>rq/add_two_ints_server/list_parametersRequest</topic>
             <topic>rq/add_two_ints_server/set_parametersRequest</topic>
             <topic>rq/add_two_ints_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_server/get_type_descriptionRequest</topic>
             <topic>rr/add_two_ints_server/describe_parametersReply</topic>
             <topic>rr/add_two_ints_server/get_parameter_typesReply</topic>
             <topic>rr/add_two_ints_server/get_parametersReply</topic>
             <topic>rr/add_two_ints_server/list_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_server/get_type_descriptionReply</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>
           </topics>
@@ -170,12 +182,14 @@
             <topic>rq/add_two_ints_client/list_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_client/get_type_descriptionRequest</topic>
             <topic>rr/add_two_ints_client/describe_parametersReply</topic>
             <topic>rr/add_two_ints_client/get_parameter_typesReply</topic>
             <topic>rr/add_two_ints_client/get_parametersReply</topic>
             <topic>rr/add_two_ints_client/list_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_client/get_type_descriptionReply</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
           </topics>
@@ -188,6 +202,7 @@
             <topic>rq/add_two_ints_client/list_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_client/get_type_descriptionRequest</topic>
             <topic>rr/add_two_intsReply</topic>
             <topic>rr/add_two_ints_client/describe_parametersReply</topic>
             <topic>rr/add_two_ints_client/get_parameter_typesReply</topic>
@@ -195,6 +210,7 @@
             <topic>rr/add_two_ints_client/list_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_client/get_type_descriptionReply</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>
           </topics>
@@ -220,6 +236,7 @@
             <topic>rq/minimal_action_server/list_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_server/get_type_descriptionRequest</topic>
             <topic>rr/fibonacci/_action/cancel_goalReply</topic>
             <topic>rr/fibonacci/_action/get_resultReply</topic>
             <topic>rr/fibonacci/_action/send_goalReply</topic>
@@ -231,6 +248,7 @@
             <topic>rr/minimal_action_server/list_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_server/get_type_descriptionReply</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
           </topics>
@@ -246,12 +264,14 @@
             <topic>rq/minimal_action_server/list_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_server/get_type_descriptionRequest</topic>
             <topic>rr/minimal_action_server/describe_parametersReply</topic>
             <topic>rr/minimal_action_server/get_parameter_typesReply</topic>
             <topic>rr/minimal_action_server/get_parametersReply</topic>
             <topic>rr/minimal_action_server/list_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_server/get_type_descriptionReply</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>
           </topics>
@@ -280,12 +300,14 @@
             <topic>rq/minimal_action_client/list_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_client/get_type_descriptionRequest</topic>
             <topic>rr/minimal_action_client/describe_parametersReply</topic>
             <topic>rr/minimal_action_client/get_parameter_typesReply</topic>
             <topic>rr/minimal_action_client/get_parametersReply</topic>
             <topic>rr/minimal_action_client/list_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_client/get_type_descriptionReply</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
           </topics>
@@ -298,6 +320,7 @@
             <topic>rq/minimal_action_client/list_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_client/get_type_descriptionRequest</topic>
             <topic>rr/fibonacci/_action/cancel_goalReply</topic>
             <topic>rr/fibonacci/_action/get_resultReply</topic>
             <topic>rr/fibonacci/_action/send_goalReply</topic>
@@ -309,6 +332,7 @@
             <topic>rr/minimal_action_client/list_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_client/get_type_descriptionReply</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>
           </topics>
@@ -335,6 +359,7 @@
             <topic>rq/admin/list_parametersRequest</topic>
             <topic>rq/admin/set_parametersRequest</topic>
             <topic>rq/admin/set_parameters_atomicallyRequest</topic>
+            <topic>rq/admin/get_type_descriptionRequest</topic>
             <topic>rq/fibonacci/_action/cancel_goalRequest</topic>
             <topic>rq/fibonacci/_action/get_resultRequest</topic>
             <topic>rq/fibonacci/_action/send_goalRequest</topic>
@@ -345,6 +370,7 @@
             <topic>rr/admin/list_parametersReply</topic>
             <topic>rr/admin/set_parametersReply</topic>
             <topic>rr/admin/set_parameters_atomicallyReply</topic>
+            <topic>rr/admin/get_type_descriptionReply</topic>
             <topic>rr/fibonacci/_action/cancel_goalReply</topic>
             <topic>rr/fibonacci/_action/get_resultReply</topic>
             <topic>rr/fibonacci/_action/send_goalReply</topic>
@@ -364,6 +390,7 @@
             <topic>rq/admin/list_parametersRequest</topic>
             <topic>rq/admin/set_parametersRequest</topic>
             <topic>rq/admin/set_parameters_atomicallyRequest</topic>
+            <topic>rq/admin/get_type_descriptionRequest</topic>
             <topic>rq/fibonacci/_action/cancel_goalRequest</topic>
             <topic>rq/fibonacci/_action/get_resultRequest</topic>
             <topic>rq/fibonacci/_action/send_goalRequest</topic>
@@ -374,6 +401,7 @@
             <topic>rr/admin/list_parametersReply</topic>
             <topic>rr/admin/set_parametersReply</topic>
             <topic>rr/admin/set_parameters_atomicallyReply</topic>
+            <topic>rr/admin/get_type_descriptionReply</topic>
             <topic>rr/fibonacci/_action/cancel_goalReply</topic>
             <topic>rr/fibonacci/_action/get_resultReply</topic>
             <topic>rr/fibonacci/_action/send_goalReply</topic>

--- a/sros2/test/policies/permissions/single_context/permissions.xml
+++ b/sros2/test/policies/permissions/single_context/permissions.xml
@@ -19,12 +19,14 @@
             <topic>rq/add_two_ints_client/list_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_client/get_type_descriptionRequest</topic>
             <topic>rq/add_two_ints_server/describe_parametersRequest</topic>
             <topic>rq/add_two_ints_server/get_parameter_typesRequest</topic>
             <topic>rq/add_two_ints_server/get_parametersRequest</topic>
             <topic>rq/add_two_ints_server/list_parametersRequest</topic>
             <topic>rq/add_two_ints_server/set_parametersRequest</topic>
             <topic>rq/add_two_ints_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_server/get_type_descriptionRequest</topic>
             <topic>rq/fibonacci/_action/cancel_goalRequest</topic>
             <topic>rq/fibonacci/_action/get_resultRequest</topic>
             <topic>rq/fibonacci/_action/send_goalRequest</topic>
@@ -34,24 +36,28 @@
             <topic>rq/listener/list_parametersRequest</topic>
             <topic>rq/listener/set_parametersRequest</topic>
             <topic>rq/listener/set_parameters_atomicallyRequest</topic>
+            <topic>rq/listener/get_type_descriptionRequest</topic>
             <topic>rq/minimal_action_client/describe_parametersRequest</topic>
             <topic>rq/minimal_action_client/get_parameter_typesRequest</topic>
             <topic>rq/minimal_action_client/get_parametersRequest</topic>
             <topic>rq/minimal_action_client/list_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_client/get_type_descriptionRequest</topic>
             <topic>rq/minimal_action_server/describe_parametersRequest</topic>
             <topic>rq/minimal_action_server/get_parameter_typesRequest</topic>
             <topic>rq/minimal_action_server/get_parametersRequest</topic>
             <topic>rq/minimal_action_server/list_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_server/get_type_descriptionRequest</topic>
             <topic>rq/talker/describe_parametersRequest</topic>
             <topic>rq/talker/get_parameter_typesRequest</topic>
             <topic>rq/talker/get_parametersRequest</topic>
             <topic>rq/talker/list_parametersRequest</topic>
             <topic>rq/talker/set_parametersRequest</topic>
             <topic>rq/talker/set_parameters_atomicallyRequest</topic>
+            <topic>rq/talker/get_type_descriptionRequest</topic>
             <topic>rr/add_two_intsReply</topic>
             <topic>rr/add_two_ints_client/describe_parametersReply</topic>
             <topic>rr/add_two_ints_client/get_parameter_typesReply</topic>
@@ -59,12 +65,14 @@
             <topic>rr/add_two_ints_client/list_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_client/get_type_descriptionReply</topic>
             <topic>rr/add_two_ints_server/describe_parametersReply</topic>
             <topic>rr/add_two_ints_server/get_parameter_typesReply</topic>
             <topic>rr/add_two_ints_server/get_parametersReply</topic>
             <topic>rr/add_two_ints_server/list_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_server/get_type_descriptionReply</topic>
             <topic>rr/fibonacci/_action/cancel_goalReply</topic>
             <topic>rr/fibonacci/_action/get_resultReply</topic>
             <topic>rr/fibonacci/_action/send_goalReply</topic>
@@ -76,24 +84,28 @@
             <topic>rr/listener/list_parametersReply</topic>
             <topic>rr/listener/set_parametersReply</topic>
             <topic>rr/listener/set_parameters_atomicallyReply</topic>
+            <topic>rr/listener/get_type_descriptionReply</topic>
             <topic>rr/minimal_action_client/describe_parametersReply</topic>
             <topic>rr/minimal_action_client/get_parameter_typesReply</topic>
             <topic>rr/minimal_action_client/get_parametersReply</topic>
             <topic>rr/minimal_action_client/list_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_client/get_type_descriptionReply</topic>
             <topic>rr/minimal_action_server/describe_parametersReply</topic>
             <topic>rr/minimal_action_server/get_parameter_typesReply</topic>
             <topic>rr/minimal_action_server/get_parametersReply</topic>
             <topic>rr/minimal_action_server/list_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_server/get_type_descriptionReply</topic>
             <topic>rr/talker/describe_parametersReply</topic>
             <topic>rr/talker/get_parameter_typesReply</topic>
             <topic>rr/talker/get_parametersReply</topic>
             <topic>rr/talker/list_parametersReply</topic>
             <topic>rr/talker/set_parametersReply</topic>
             <topic>rr/talker/set_parameters_atomicallyReply</topic>
+            <topic>rr/talker/get_type_descriptionReply</topic>
             <topic>rt/chatter</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
@@ -108,12 +120,14 @@
             <topic>rq/add_two_ints_client/list_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parametersRequest</topic>
             <topic>rq/add_two_ints_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_client/get_type_descriptionRequest</topic>
             <topic>rq/add_two_ints_server/describe_parametersRequest</topic>
             <topic>rq/add_two_ints_server/get_parameter_typesRequest</topic>
             <topic>rq/add_two_ints_server/get_parametersRequest</topic>
             <topic>rq/add_two_ints_server/list_parametersRequest</topic>
             <topic>rq/add_two_ints_server/set_parametersRequest</topic>
             <topic>rq/add_two_ints_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/add_two_ints_server/get_type_descriptionRequest</topic>
             <topic>rq/fibonacci/_action/cancel_goalRequest</topic>
             <topic>rq/fibonacci/_action/get_resultRequest</topic>
             <topic>rq/fibonacci/_action/send_goalRequest</topic>
@@ -123,24 +137,28 @@
             <topic>rq/listener/list_parametersRequest</topic>
             <topic>rq/listener/set_parametersRequest</topic>
             <topic>rq/listener/set_parameters_atomicallyRequest</topic>
+            <topic>rq/listener/get_type_descriptionRequest</topic>
             <topic>rq/minimal_action_client/describe_parametersRequest</topic>
             <topic>rq/minimal_action_client/get_parameter_typesRequest</topic>
             <topic>rq/minimal_action_client/get_parametersRequest</topic>
             <topic>rq/minimal_action_client/list_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parametersRequest</topic>
             <topic>rq/minimal_action_client/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_client/get_type_descriptionRequest</topic>
             <topic>rq/minimal_action_server/describe_parametersRequest</topic>
             <topic>rq/minimal_action_server/get_parameter_typesRequest</topic>
             <topic>rq/minimal_action_server/get_parametersRequest</topic>
             <topic>rq/minimal_action_server/list_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parametersRequest</topic>
             <topic>rq/minimal_action_server/set_parameters_atomicallyRequest</topic>
+            <topic>rq/minimal_action_server/get_type_descriptionRequest</topic>
             <topic>rq/talker/describe_parametersRequest</topic>
             <topic>rq/talker/get_parameter_typesRequest</topic>
             <topic>rq/talker/get_parametersRequest</topic>
             <topic>rq/talker/list_parametersRequest</topic>
             <topic>rq/talker/set_parametersRequest</topic>
             <topic>rq/talker/set_parameters_atomicallyRequest</topic>
+            <topic>rq/talker/get_type_descriptionRequest</topic>
             <topic>rr/add_two_intsReply</topic>
             <topic>rr/add_two_ints_client/describe_parametersReply</topic>
             <topic>rr/add_two_ints_client/get_parameter_typesReply</topic>
@@ -148,12 +166,14 @@
             <topic>rr/add_two_ints_client/list_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parametersReply</topic>
             <topic>rr/add_two_ints_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_client/get_type_descriptionReply</topic>
             <topic>rr/add_two_ints_server/describe_parametersReply</topic>
             <topic>rr/add_two_ints_server/get_parameter_typesReply</topic>
             <topic>rr/add_two_ints_server/get_parametersReply</topic>
             <topic>rr/add_two_ints_server/list_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parametersReply</topic>
             <topic>rr/add_two_ints_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/add_two_ints_server/get_type_descriptionReply</topic>
             <topic>rr/fibonacci/_action/cancel_goalReply</topic>
             <topic>rr/fibonacci/_action/get_resultReply</topic>
             <topic>rr/fibonacci/_action/send_goalReply</topic>
@@ -165,24 +185,28 @@
             <topic>rr/listener/list_parametersReply</topic>
             <topic>rr/listener/set_parametersReply</topic>
             <topic>rr/listener/set_parameters_atomicallyReply</topic>
+            <topic>rr/listener/get_type_descriptionReply</topic>
             <topic>rr/minimal_action_client/describe_parametersReply</topic>
             <topic>rr/minimal_action_client/get_parameter_typesReply</topic>
             <topic>rr/minimal_action_client/get_parametersReply</topic>
             <topic>rr/minimal_action_client/list_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parametersReply</topic>
             <topic>rr/minimal_action_client/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_client/get_type_descriptionReply</topic>
             <topic>rr/minimal_action_server/describe_parametersReply</topic>
             <topic>rr/minimal_action_server/get_parameter_typesReply</topic>
             <topic>rr/minimal_action_server/get_parametersReply</topic>
             <topic>rr/minimal_action_server/list_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parametersReply</topic>
             <topic>rr/minimal_action_server/set_parameters_atomicallyReply</topic>
+            <topic>rr/minimal_action_server/get_type_descriptionReply</topic>
             <topic>rr/talker/describe_parametersReply</topic>
             <topic>rr/talker/get_parameter_typesReply</topic>
             <topic>rr/talker/get_parametersReply</topic>
             <topic>rr/talker/list_parametersReply</topic>
             <topic>rr/talker/set_parametersReply</topic>
             <topic>rr/talker/set_parameters_atomicallyReply</topic>
+            <topic>rr/talker/get_type_descriptionReply</topic>
             <topic>rt/chatter</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>

--- a/sros2/test/policies/permissions/talker_listener/permissions.xml
+++ b/sros2/test/policies/permissions/talker_listener/permissions.xml
@@ -18,12 +18,14 @@
             <topic>rq/talker/list_parametersRequest</topic>
             <topic>rq/talker/set_parametersRequest</topic>
             <topic>rq/talker/set_parameters_atomicallyRequest</topic>
+            <topic>rq/talker/get_type_descriptionRequest</topic>
             <topic>rr/talker/describe_parametersReply</topic>
             <topic>rr/talker/get_parameter_typesReply</topic>
             <topic>rr/talker/get_parametersReply</topic>
             <topic>rr/talker/list_parametersReply</topic>
             <topic>rr/talker/set_parametersReply</topic>
             <topic>rr/talker/set_parameters_atomicallyReply</topic>
+            <topic>rr/talker/get_type_descriptionReply</topic>
             <topic>rt/chatter</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
@@ -37,12 +39,14 @@
             <topic>rq/talker/list_parametersRequest</topic>
             <topic>rq/talker/set_parametersRequest</topic>
             <topic>rq/talker/set_parameters_atomicallyRequest</topic>
+            <topic>rq/talker/get_type_descriptionRequest</topic>
             <topic>rr/talker/describe_parametersReply</topic>
             <topic>rr/talker/get_parameter_typesReply</topic>
             <topic>rr/talker/get_parametersReply</topic>
             <topic>rr/talker/list_parametersReply</topic>
             <topic>rr/talker/set_parametersReply</topic>
             <topic>rr/talker/set_parameters_atomicallyReply</topic>
+            <topic>rr/talker/get_type_descriptionReply</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>
           </topics>
@@ -68,12 +72,14 @@
             <topic>rq/listener/list_parametersRequest</topic>
             <topic>rq/listener/set_parametersRequest</topic>
             <topic>rq/listener/set_parameters_atomicallyRequest</topic>
+            <topic>rq/listener/get_type_descriptionRequest</topic>
             <topic>rr/listener/describe_parametersReply</topic>
             <topic>rr/listener/get_parameter_typesReply</topic>
             <topic>rr/listener/get_parametersReply</topic>
             <topic>rr/listener/list_parametersReply</topic>
             <topic>rr/listener/set_parametersReply</topic>
             <topic>rr/listener/set_parameters_atomicallyReply</topic>
+            <topic>rr/listener/get_type_descriptionReply</topic>
             <topic>rt/parameter_events</topic>
             <topic>rt/rosout</topic>
           </topics>
@@ -86,12 +92,14 @@
             <topic>rq/listener/list_parametersRequest</topic>
             <topic>rq/listener/set_parametersRequest</topic>
             <topic>rq/listener/set_parameters_atomicallyRequest</topic>
+            <topic>rq/listener/get_type_descriptionRequest</topic>
             <topic>rr/listener/describe_parametersReply</topic>
             <topic>rr/listener/get_parameter_typesReply</topic>
             <topic>rr/listener/get_parametersReply</topic>
             <topic>rr/listener/list_parametersReply</topic>
             <topic>rr/listener/set_parametersReply</topic>
             <topic>rr/listener/set_parameters_atomicallyReply</topic>
+            <topic>rr/listener/get_type_descriptionReply</topic>
             <topic>rt/chatter</topic>
             <topic>rt/clock</topic>
             <topic>rt/parameter_events</topic>


### PR DESCRIPTION
(Tested only on Linux)

- clone the sros2 repo in a temporary directory to retrieve test policies from it
  - the subversion hack doesnt work anymore..
- add `get_type_description` service to a standard node policy
  - otherwise the node won't start as this service and associated topics are created by default
- minor fixups to README and tutorials