### PR TITLE
Timezone aware datetimes + remove hack from #209

### DIFF
--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>python3-cryptography</exec_depend>
   <exec_depend>python3-importlib-resources</exec_depend>
   <exec_depend>python3-lxml</exec_depend>
+  <exec_depend>python3-semver</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2cli</exec_depend>
 

--- a/sros2/package.xml
+++ b/sros2/package.xml
@@ -15,7 +15,6 @@
   <exec_depend>python3-cryptography</exec_depend>
   <exec_depend>python3-importlib-resources</exec_depend>
   <exec_depend>python3-lxml</exec_depend>
-  <exec_depend>python3-semver</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2cli</exec_depend>
 

--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -80,17 +80,14 @@ def build_key_and_cert(subject_name, *, ca=False, ca_key=None, issuer_name=''):
     else:
         extension = x509.BasicConstraints(ca=False, path_length=None)
 
-    utcnow = datetime.datetime.utcnow()
+    utcnow = datetime.datetime.now(datetime.timezone.utc)
     builder = x509.CertificateBuilder(
         ).issuer_name(
             issuer_name
         ).serial_number(
             x509.random_serial_number()
         ).not_valid_before(
-            # Using a day earlier here to prevent Connext (5.3.1) from complaining
-            # when extracting it from the permissions file and thinking it's in the future
-            # https://github.com/ros2/ci/pull/436#issuecomment-624874296
-            utcnow - datetime.timedelta(days=1)
+            utcnow
         ).not_valid_after(
             # TODO: This should not be hard-coded
             utcnow + datetime.timedelta(days=3650)

--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -17,14 +17,11 @@ import datetime
 import os
 import pathlib
 
-import cryptography
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend as cryptography_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
-
-import semver
 
 import sros2.errors
 
@@ -39,10 +36,6 @@ def create_symlink(*, src: pathlib.Path, dst: pathlib.Path):
             return
         os.remove(dst)
     os.symlink(src, dst)
-
-
-def cryptography_version() -> semver.VersionInfo:
-    return semver.parse_version_info(cryptography.__version__)
 
 
 def domain_id() -> str:

--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -17,11 +17,14 @@ import datetime
 import os
 import pathlib
 
+import cryptography
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend as cryptography_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+
+import semver
 
 import sros2.errors
 
@@ -36,6 +39,10 @@ def create_symlink(*, src: pathlib.Path, dst: pathlib.Path):
             return
         os.remove(dst)
     os.symlink(src, dst)
+
+
+def cryptography_version() -> semver.VersionInfo:
+    return semver.parse_version_info(cryptography.__version__)
 
 
 def domain_id() -> str:

--- a/sros2/sros2/keystore/_permission.py
+++ b/sros2/sros2/keystore/_permission.py
@@ -75,8 +75,15 @@ def create_permission_file(path: pathlib.Path, domain_id, policy_element) -> Non
 
     cert_path = path.parent.joinpath('cert.pem')
     cert_content = _utilities.load_cert(cert_path)
-    kwargs['not_valid_before'] = etree.XSLT.strparam(cert_content.not_valid_before.isoformat())
-    kwargs['not_valid_after'] = etree.XSLT.strparam(cert_content.not_valid_after.isoformat())
+    # TODO replace "not_valid_before"/"not_valid_after" functions by
+    # "not_valid_before_utc"/"not_valid_after_utc"
+    # once cryptography 42 is supported on all target platforms
+    kwargs['not_valid_before'] = etree.XSLT.strparam(
+        cert_content.not_valid_before.replace(tzinfo=datetime.timezone.utc).isoformat()
+    )
+    kwargs['not_valid_after'] = etree.XSLT.strparam(
+        cert_content.not_valid_after.replace(tzinfo=datetime.timezone.utc).isoformat()
+    )
 
     if get_rmw_implementation_identifier() in _RMW_WITH_ROS_GRAPH_INFO_TOPIC:
         kwargs['allow_ros_discovery_topic'] = etree.XSLT.strparam('1')

--- a/sros2/sros2/keystore/_permission.py
+++ b/sros2/sros2/keystore/_permission.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import os
 import pathlib
 

--- a/sros2/sros2/keystore/_permission.py
+++ b/sros2/sros2/keystore/_permission.py
@@ -76,15 +76,20 @@ def create_permission_file(path: pathlib.Path, domain_id, policy_element) -> Non
 
     cert_path = path.parent.joinpath('cert.pem')
     cert_content = _utilities.load_cert(cert_path)
-    # TODO replace "not_valid_before"/"not_valid_after" functions by
-    # "not_valid_before_utc"/"not_valid_after_utc"
-    # once cryptography 42 is supported on all target platforms
-    kwargs['not_valid_before'] = etree.XSLT.strparam(
-        cert_content.not_valid_before.replace(tzinfo=datetime.timezone.utc).isoformat()
-    )
-    kwargs['not_valid_after'] = etree.XSLT.strparam(
-        cert_content.not_valid_after.replace(tzinfo=datetime.timezone.utc).isoformat()
-    )
+    if _utilities.cryptography_version().major >= 42:
+        kwargs['not_valid_before'] = etree.XSLT.strparam(
+            cert_content.not_valid_before_utc
+        )
+        kwargs['not_valid_after'] = etree.XSLT.strparam(
+            cert_content.not_valid_after_utc
+        )
+    else:
+        kwargs['not_valid_before'] = etree.XSLT.strparam(
+            cert_content.not_valid_before.replace(tzinfo=datetime.timezone.utc).isoformat()
+        )
+        kwargs['not_valid_after'] = etree.XSLT.strparam(
+            cert_content.not_valid_after.replace(tzinfo=datetime.timezone.utc).isoformat()
+        )
 
     if get_rmw_implementation_identifier() in _RMW_WITH_ROS_GRAPH_INFO_TOPIC:
         kwargs['allow_ros_discovery_topic'] = etree.XSLT.strparam('1')

--- a/sros2/sros2/keystore/_permission.py
+++ b/sros2/sros2/keystore/_permission.py
@@ -76,17 +76,23 @@ def create_permission_file(path: pathlib.Path, domain_id, policy_element) -> Non
 
     cert_path = path.parent.joinpath('cert.pem')
     cert_content = _utilities.load_cert(cert_path)
-    if _utilities.cryptography_version().major >= 42:
+    # TODO use `not_valid_before_utc` unconditionally once cryptography 42 is available
+    # on all target platforms
+    if hasattr(cert_content, 'not_valid_before_utc'):
         kwargs['not_valid_before'] = etree.XSLT.strparam(
-            cert_content.not_valid_before_utc
-        )
-        kwargs['not_valid_after'] = etree.XSLT.strparam(
-            cert_content.not_valid_after_utc
+            cert_content.not_valid_before_utc.isoformat()
         )
     else:
         kwargs['not_valid_before'] = etree.XSLT.strparam(
             cert_content.not_valid_before.replace(tzinfo=datetime.timezone.utc).isoformat()
         )
+    # TODO use `not_valid_after_utc` unconditionally once cryptography 42 is available
+    # on all target platforms
+    if hasattr(cert_content, 'not_valid_after_utc'):
+        kwargs['not_valid_after'] = etree.XSLT.strparam(
+            cert_content.not_valid_after_utc.isoformat()
+        )
+    else:
         kwargs['not_valid_after'] = etree.XSLT.strparam(
             cert_content.not_valid_after.replace(tzinfo=datetime.timezone.utc).isoformat()
         )

--- a/sros2/sros2/policy/templates/dds/permissions.xsl
+++ b/sros2/sros2/policy/templates/dds/permissions.xsl
@@ -6,8 +6,8 @@
  <xsl:output omit-xml-declaration="yes" indent="yes"/>
  <xsl:strip-space elements="*"/>
 
-<xsl:param name="not_valid_before" select="'2020-05-01T00:00:00'"/>
-<xsl:param name="not_valid_after" select="'2030-05-01T00:00:00'"/>
+<xsl:param name="not_valid_before" select="'2020-05-01T00:00:00+00:00'"/>
+<xsl:param name="not_valid_after" select="'2030-05-01T00:00:00+00:00'"/>
 
 <xsl:variable name="template_validity">
   <validity>

--- a/sros2/test/policies/permissions/add_two_ints/permissions.xml
+++ b/sros2/test/policies/permissions/add_two_ints/permissions.xml
@@ -3,8 +3,8 @@
     <grant name="/add_two_ints/add_two_ints_server">
       <subject_name>CN=/add_two_ints/add_two_ints_server</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>
@@ -56,8 +56,8 @@
     <grant name="/add_two_ints/add_two_ints_client">
       <subject_name>CN=/add_two_ints/add_two_ints_client</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>

--- a/sros2/test/policies/permissions/minimal_action/permissions.xml
+++ b/sros2/test/policies/permissions/minimal_action/permissions.xml
@@ -3,8 +3,8 @@
     <grant name="/minimal_action/minimal_action_server">
       <subject_name>CN=/minimal_action/minimal_action_server</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>
@@ -64,8 +64,8 @@
     <grant name="/minimal_action/minimal_action_client">
       <subject_name>CN=/minimal_action/minimal_action_client</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>

--- a/sros2/test/policies/permissions/sample/permissions.xml
+++ b/sros2/test/policies/permissions/sample/permissions.xml
@@ -3,8 +3,8 @@
     <grant name="/talker_listener/talker">
       <subject_name>CN=/talker_listener/talker</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>
@@ -57,8 +57,8 @@
     <grant name="/talker_listener/listener">
       <subject_name>CN=/talker_listener/listener</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>
@@ -111,8 +111,8 @@
     <grant name="/add_two_ints/add_two_ints_server">
       <subject_name>CN=/add_two_ints/add_two_ints_server</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>
@@ -166,8 +166,8 @@
     <grant name="/add_two_ints/add_two_ints_client">
       <subject_name>CN=/add_two_ints/add_two_ints_client</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>
@@ -221,8 +221,8 @@
     <grant name="/minimal_action/minimal_action_server">
       <subject_name>CN=/minimal_action/minimal_action_server</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>
@@ -282,8 +282,8 @@
     <grant name="/minimal_action/minimal_action_client">
       <subject_name>CN=/minimal_action/minimal_action_client</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>
@@ -343,8 +343,8 @@
     <grant name="/sample_policy/admin">
       <subject_name>CN=/sample_policy/admin</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>

--- a/sros2/test/policies/permissions/single_context/permissions.xml
+++ b/sros2/test/policies/permissions/single_context/permissions.xml
@@ -3,8 +3,8 @@
     <grant name="/single_enclave">
       <subject_name>CN=/single_enclave</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>

--- a/sros2/test/policies/permissions/talker_listener/permissions.xml
+++ b/sros2/test/policies/permissions/talker_listener/permissions.xml
@@ -3,8 +3,8 @@
     <grant name="/talker_listener/talker">
       <subject_name>CN=/talker_listener/talker</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>
@@ -57,8 +57,8 @@
     <grant name="/talker_listener/listener">
       <subject_name>CN=/talker_listener/listener</subject_name>
       <validity>
-        <not_before>2020-05-01T00:00:00</not_before>
-        <not_after>2030-05-01T00:00:00</not_after>
+        <not_before>2020-05-01T00:00:00+00:00</not_before>
+        <not_after>2030-05-01T00:00:00+00:00</not_after>
       </validity>
       <allow_rule>
         <domains>

--- a/sros2/test/sros2/commands/security/verbs/test_create_enclave.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_enclave.py
@@ -124,15 +124,19 @@ def test_cert_pem(enclave_keys_dir):
     # Verify the cert is valid for the expected timespan
     utcnow = datetime.datetime.now(datetime.timezone.utc)
 
-    # TODO replace "not_valid_before"/"not_valid_after" functions by
-    # "not_valid_before_utc"/"not_valid_after_utc"
-    # once cryptography 42 is supported on all target platforms
+    if _utilities.cryptography_version().major >= 42:
+        cert_not_valid_before_value = cert.not_valid_before_utc
+        cert_not_valid_after_value = cert.not_valid_after_utc
+    else:
+        cert_not_valid_before_value = cert.not_valid_before.replace(tzinfo=datetime.timezone.utc)
+        cert_not_valid_after_value = cert.not_valid_after.replace(tzinfo=datetime.timezone.utc)
+
     assert _datetimes_are_close(
-        cert.not_valid_before.replace(tzinfo=datetime.timezone.utc),
+        cert_not_valid_before_value,
         utcnow
     )
     assert _datetimes_are_close(
-        cert.not_valid_after.replace(tzinfo=datetime.timezone.utc),
+        cert_not_valid_after_value,
         utcnow + datetime.timedelta(days=3650)
     )
 

--- a/sros2/test/sros2/commands/security/verbs/test_create_enclave.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_enclave.py
@@ -124,11 +124,18 @@ def test_cert_pem(enclave_keys_dir):
     # Verify the cert is valid for the expected timespan
     utcnow = datetime.datetime.now(datetime.timezone.utc)
 
-    if _utilities.cryptography_version().major >= 42:
+    # TODO use `not_valid_before_utc` unconditionally once cryptography 42 is available
+    # on all target platforms
+    if hasattr(cert, 'not_valid_before_utc'):
         cert_not_valid_before_value = cert.not_valid_before_utc
-        cert_not_valid_after_value = cert.not_valid_after_utc
     else:
         cert_not_valid_before_value = cert.not_valid_before.replace(tzinfo=datetime.timezone.utc)
+
+    # TODO use `not_valid_after_utc` unconditionally once cryptography 42 is available
+    # on all target platforms
+    if hasattr(cert, 'not_valid_after_utc'):
+        cert_not_valid_after_value = cert.not_valid_after_utc
+    else:
         cert_not_valid_after_value = cert.not_valid_after.replace(tzinfo=datetime.timezone.utc)
 
     assert _datetimes_are_close(

--- a/sros2/test/sros2/commands/security/verbs/test_create_enclave.py
+++ b/sros2/test/sros2/commands/security/verbs/test_create_enclave.py
@@ -122,13 +122,19 @@ def test_cert_pem(enclave_keys_dir):
     assert isinstance(cert.signature_hash_algorithm, hashes.SHA256)
 
     # Verify the cert is valid for the expected timespan
-    utcnow = datetime.datetime.utcnow()
+    utcnow = datetime.datetime.now(datetime.timezone.utc)
 
-    # Using a day earlier here to prevent Connext (5.3.1) from complaining
-    # when extracting it from the permissions file and thinking it's in the future
-    # https://github.com/ros2/ci/pull/436#issuecomment-624874296
-    assert _datetimes_are_close(cert.not_valid_before, utcnow - datetime.timedelta(days=1))
-    assert _datetimes_are_close(cert.not_valid_after, utcnow + datetime.timedelta(days=3650))
+    # TODO replace "not_valid_before"/"not_valid_after" functions by
+    # "not_valid_before_utc"/"not_valid_after_utc"
+    # once cryptography 42 is supported on all target platforms
+    assert _datetimes_are_close(
+        cert.not_valid_before.replace(tzinfo=datetime.timezone.utc),
+        utcnow
+    )
+    assert _datetimes_are_close(
+        cert.not_valid_after.replace(tzinfo=datetime.timezone.utc),
+        utcnow + datetime.timedelta(days=3650)
+    )
 
     # Verify that the cert ensures this key cannot be used to sign others as a CA
     assert len(cert.extensions) == 1


### PR DESCRIPTION
This PR (basically a redo of https://github.com/ros2/sros2/pull/210) does:

- Set timezone to UTC explicitly in all security artifacts
  - this allows to remove the -1 day hack from https://github.com/ros2/sros2/pull/209
  - I don't think it fixes any kind of issue and would assume the issue have been fixed on the connext side in version 6
  - But I think it's more explicit and doesnt hurt
- Make python datetime object timezone-aware, as this will be mandatory in future versions of python and reduces unexpected behaviors


I dont have a connext setup (license plugins etc right now) and the ROS 2 CI machines seem to be UTC so maybe they wont reflect the issue. If a reviewer that is behind UTC and has the right setup can give it a try that'd be awesome