### PR TITLE
[CI] Reenabling source test and coverage workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,13 @@ jobs:
     # the former gets installed via rosdep in 'action-ros-ci' but the latter do *not* get installed
     container: osrf/ros2:devel
     steps:
-    - uses: ros-tooling/setup-ros@v0.7
     - name: Install prerequisites for action-ros-ci and FastRTPS
       run: |
         apt-get -qq update
         apt-get -qq upgrade -y
-        apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev python3-colcon-coveragepy-result
+        apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev python3-colcon-coveragepy-result python3-pytest-cov
     - uses: ros-tooling/action-ros-ci@v0.3
       with:
-        # TODO remove once https://github.com/ros-tooling/action-ros-ci/pull/869 is released
         rosdep-skip-keys: rti-connext-dds-6.0.1
         package-name: |
           sros2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/rolling')
       with:
         file: ros_ws/build/sros2/coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,16 @@ jobs:
           sros2_cmake
           test_security
         extra-cmake-args: '-DSECURITY=ON --no-warn-unused-cli'
+        colcon-defaults: |
+          {
+            "build": {
+              "mixin": ["coverage-pytest"]
+            },
+            "test": {
+              "mixin": ["coverage-pytest"]
+            }
+          }
+        colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
         target-ros2-distro: rolling
           # rosdep-skip-keys: rti-connext-dds-6.0.1
     - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,8 @@ jobs:
           }
         colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
         target-ros2-distro: rolling
-          # rosdep-skip-keys: rti-connext-dds-6.0.1
+        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/rolling')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,13 @@ jobs:
     # the former gets installed via rosdep in 'action-ros-ci' but the latter do *not* get installed
     container: osrf/ros2:devel
     steps:
+    - uses: ros-tooling/setup-ros@v0.7
     - name: Install prerequisites for action-ros-ci and FastRTPS
       run: |
         apt-get -qq update
         apt-get -qq upgrade -y
         apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev python3-colcon-coveragepy-result
-    - uses: mikaelarguedas/action-ros-ci@skip-connext-6-0-1
+    - uses: ros-tooling/action-ros-ci@v0.3
       with:
         package-name: |
           sros2
@@ -28,7 +29,7 @@ jobs:
         target-ros2-distro: rolling
           # rosdep-skip-keys: rti-connext-dds-6.0.1
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/rolling')
       with:
         file: ros_ws/build/sros2/coverage.xml
@@ -36,7 +37,7 @@ jobs:
         name: sros2-coverage
         fail_ci_if_error: true
     - name: Upload Logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: colcon-logs
@@ -47,7 +48,7 @@ jobs:
     # does *not* include the security plugins or a license allowing the use of Security
     container: osrf/ros2:nightly-rmw-nonfree
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Installing dependencies
       run: |
         apt-get -qq update
@@ -62,7 +63,7 @@ jobs:
     - name: Check test results
       run: colcon test-result
     - name: Upload Logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: colcon-logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: SROS2 CI
 on:
   pull_request:
   push:
+    branches:
+      rolling
   schedule:
     # Run daily
     - cron:  '0 20 * * *'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,40 +7,40 @@ on:
     - cron:  '0 20 * * *'
 
 jobs:
-  # test_latest:
-  #   runs-on: ubuntu-latest
-  #   # 'osrf/ros2:devel' does *not* include RTI Connext or its' security plugins
-  #   # the former gets installed via rosdep in 'action-ros-ci' but the latter do *not* get installed
-  #   container: osrf/ros2:devel
-  #   steps:
-  #   - name: Install prerequisites for action-ros-ci and FastRTPS
-  #     run: |
-  #       apt-get -qq update
-  #       apt-get -qq upgrade -y
-  #       apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev python3-colcon-coveragepy-result
-  #   - uses: ros-tooling/action-ros-ci@v0.3
-  #     with:
-  #       package-name: |
-  #         sros2
-  #         sros2_cmake
-  #         test_security
-  #       extra-cmake-args: '-DSECURITY=ON --no-warn-unused-cli'
-  #       target-ros2-distro: rolling
-  #       rosdep-skip-keys: rti-connext-dds-6.0.1
-  #   - name: Upload coverage to Codecov
-  #     uses: codecov/codecov-action@v1
-  #     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/rolling')
-  #     with:
-  #       file: ros_ws/build/sros2/coverage.xml
-  #       flags: unittests
-  #       name: sros2-coverage
-  #       fail_ci_if_error: true
-  #   - name: Upload Logs
-  #     uses: actions/upload-artifact@v1
-  #     if: failure()
-  #     with:
-  #       name: colcon-logs
-  #       path: ros_ws/log
+  test_latest:
+    runs-on: ubuntu-latest
+    # 'osrf/ros2:devel' does *not* include RTI Connext or its' security plugins
+    # the former gets installed via rosdep in 'action-ros-ci' but the latter do *not* get installed
+    container: osrf/ros2:devel
+    steps:
+    - name: Install prerequisites for action-ros-ci and FastRTPS
+      run: |
+        apt-get -qq update
+        apt-get -qq upgrade -y
+        apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev python3-colcon-coveragepy-result
+    - uses: mikaelarguedas/action-ros-ci@skip-connext-6-0-1
+      with:
+        package-name: |
+          sros2
+          sros2_cmake
+          test_security
+        extra-cmake-args: '-DSECURITY=ON --no-warn-unused-cli'
+        target-ros2-distro: rolling
+          # rosdep-skip-keys: rti-connext-dds-6.0.1
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/rolling')
+      with:
+        file: ros_ws/build/sros2/coverage.xml
+        flags: unittests
+        name: sros2-coverage
+        fail_ci_if_error: true
+    - name: Upload Logs
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: colcon-logs
+        path: ros_ws/log
   test_nightly:
     runs-on: ubuntu-latest
     # 'osrf/ros2:nightly-rmw-nonfree' includes RTI Connext but

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev python3-colcon-coveragepy-result
     - uses: ros-tooling/action-ros-ci@v0.3
       with:
+        # TODO remove once https://github.com/ros-tooling/action-ros-ci/pull/869 is released
+        rosdep-skip-keys: rti-connext-dds-6.0.1
         package-name: |
           sros2
           sros2_cmake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         apt-get -qq update
         apt-get -qq upgrade -y
-        apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev python3-colcon-coveragepy-result python3-pytest-cov
+        apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev python3-colcon-coveragepy-result
     - uses: ros-tooling/action-ros-ci@v0.3
       with:
         rosdep-skip-keys: rti-connext-dds-6.0.1


### PR DESCRIPTION
Follow-up of https://github.com/ros2/sros2/pull/299