### PR TITLE
add back codecov.yml config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
         flags: unittests
         name: sros2-coverage
         fail_ci_if_error: true
+        codecov_yml_path: codecov.yml
     - name: Upload Logs
       uses: actions/upload-artifact@v4
       if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
         package-name: |
           sros2
           sros2_cmake
-          test_security
         extra-cmake-args: '-DSECURITY=ON --no-warn-unused-cli'
         colcon-defaults: |
           {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         package-name: |
           sros2
           sros2_cmake
+          test_security
         extra-cmake-args: '-DSECURITY=ON --no-warn-unused-cli'
         colcon-defaults: |
           {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 fixes:
-  - "ros_ws/src/*/sros2::"
+  - "/__w/sros2/sros2/ros_ws/src/*/sros2::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 fixes:
-  - "ros_ws/src/sros2/::"
+  - "ros_ws/src/*/sros2::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 fixes:
-  - "/__w/sros2/sros2/ros_ws/src/*/sros2::"
+  - "::sros2/"


### PR DESCRIPTION
Roll back https://github.com/ros2/sros2/pull/185
Using new `codecov_yml_path` argument: https://github.com/codecov/codecov-action?tab=readme-ov-file#arguments

This should fix coverage visualization on codecov.io