### PR TITLE
[DOC] Fixup CI Readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Context
 
-[![SROS2 CI](https://github.com/ros2/sros2/workflows/SROS2%20CI/badge.svg)](https://github.com/ros2/sros2/actions?query=workflow%3A%22SROS2+CI%22+branch%3Arolling)
+[![SROS2 CI](https://img.shields.io/github/actions/workflow/status/ros2/sros2/test.yml?branch=rolling)](https://github.com/ros2/sros2/actions?query=workflow%3A%22SROS2+CI%22+branch%3Arolling)
 [![codecov](https://codecov.io/gh/ros2/sros2/branch/rolling/graph/badge.svg)](https://codecov.io/gh/ros2/sros2)
 
 This package provides the tools and instructions to use ROS 2 on top of DDS-Security.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Context
-
-[![SROS2 CI](https://img.shields.io/github/actions/workflow/status/ros2/sros2/test.yml?branch=rolling)](https://github.com/ros2/sros2/actions?query=workflow%3A%22SROS2+CI%22+branch%3Arolling)
+[![SROS2 CI](https://github.com/ros2/sros2/actions/workflows/test.yml/badge.svg?branch=rolling)](https://github.com/ros2/sros2/actions/workflows/test.yml?query=branch%3Arolling)
 [![codecov](https://codecov.io/gh/ros2/sros2/branch/rolling/graph/badge.svg)](https://codecov.io/gh/ros2/sros2)
 
 This package provides the tools and instructions to use ROS 2 on top of DDS-Security.


### PR DESCRIPTION
github action badge not displaying actual status because not pointing to the right branch.

![Screenshot from 2024-05-08 19-13-07](https://github.com/ros2/sros2/assets/6644208/0b92a91b-50b1-4d98-b23e-e2b0536272a0)


With this change it's displaying the status of the rolling branch and not the status of the last job ran