### PR TITLE
Fix sros2 tests on Windows Debug.

### DIFF
--- a/sros2/sros2/api/_policy.py
+++ b/sros2/sros2/api/_policy.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
+
 from lxml import etree
 
 from sros2.policy import load_policy
@@ -28,7 +30,7 @@ def get_policy_from_tree(name, policy_tree):
     if enclave_element is None:
         raise RuntimeError(f'unable to find enclave "{name}"')
     enclaves_element = etree.Element('enclaves')
-    enclaves_element.append(enclave_element)
+    enclaves_element.append(deepcopy(enclave_element))
     policy_element = etree.Element('policy')
     policy_element.append(enclaves_element)
     return policy_element


### PR DESCRIPTION
From what I can tell, it looks like lxml has a bug where it doesn't properly track references to objects via the find() method.  This manifests on Windows debug as a crash *after* we have stopped using the object, but I believe that by that point the underlying memory has already been freed.  Windows Debug in particular is sensitive to this.

Fix it by doing a deepcopy of the object returned from the find().  This code isn't performance sensitive, so it shouldn't be a big deal to do it here, and it fixes the bug in my testing.