### PR TITLE
[FIX] remove dangerous mutable default arguments in generate_artifacts

### DIFF
--- a/sros2/sros2/api/_artifact_generation.py
+++ b/sros2/sros2/api/_artifact_generation.py
@@ -21,16 +21,15 @@ from sros2.policy import load_policy
 from . import _policy
 
 
-# FIXME move away from mutable default (linter should complain about it)
 def generate_artifacts(
-    keystore_path: Optional[pathlib.Path] = None,
-    identity_names: List[str] = [],
-    policy_files: List[pathlib.Path] = []
+    keystore_path: Optional[pathlib.Path],
+    identity_names: List[str],
+    policy_files: List[pathlib.Path]
 ) -> None:
     if keystore_path is None:
         keystore_path = _utilities.get_keystore_path_from_env()
         if keystore_path is None:
-            return False
+            return
     if not keystore.is_valid_keystore(keystore_path):
         print('%s is not a valid keystore, creating new keystore' % keystore_path)
         keystore.create_keystore(keystore_path)


### PR DESCRIPTION
You cannot safely use = [] as a default argument in Python; subsequent calls will reuse that object.  It probably doesn't matter in this case, as these are all "read-only" arguments, but it is better not to do it at all.  Instead, we recognize that this function is always called with all of its arguments, so there is no need for default arguments at all.

While in here, I noticed that, generate_artifacts was returning a boolean on an error path, which is not allowed by its signature.  So fix that as well.