### PR TITLE
Switch to context manager for rclpy tests.

### DIFF
--- a/sros2/test/sros2/commands/security/verbs/fixtures/client_service_node.py
+++ b/sros2/test/sros2/commands/security/verbs/fixtures/client_service_node.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 import test_msgs.srv
@@ -34,17 +35,12 @@ class ClientServiceNode(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = ClientServiceNode()
-
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init(args=args):
+            node = ClientServiceNode()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         print('node stopped cleanly')
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
 
 
 if __name__ == '__main__':

--- a/sros2/test/sros2/commands/security/verbs/fixtures/pub_sub_node.py
+++ b/sros2/test/sros2/commands/security/verbs/fixtures/pub_sub_node.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 import test_msgs.msg
@@ -37,17 +38,12 @@ class PubSubNode(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = PubSubNode()
-
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init(args=args):
+            node = PubSubNode()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         print('node stopped cleanly')
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows us to use less code, but still properly clean up when we are done with rclpy.