### PR TITLE
Give more time to generate policies in tests

### DIFF
--- a/sros2/test/sros2/commands/security/verbs/test_generate_policy_no_nodes.py
+++ b/sros2/test/sros2/commands/security/verbs/test_generate_policy_no_nodes.py
@@ -47,7 +47,7 @@ def generate_test_description(rmw_implementation, use_daemon):
     ), locals()
 
 
-GENERATE_POLICY_TIMEOUT = 10 if os.name != 'nt' else 30  # seconds
+GENERATE_POLICY_TIMEOUT = 30 if os.name != 'nt' else 60  # seconds
 
 
 class TestSROS2GeneratePolicyVerbWithNoNodes(SROS2CLITestCase):


### PR DESCRIPTION
Related with this PR https://github.com/ros2/sros2/issues/321

I was playing with the linked flaky issue and my guess is that the policy is not generated because it required more time.