### PR TITLE
Use multiple CAs instead of a single self-signed root CA

### DIFF
--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -108,7 +108,7 @@ def build_key_and_cert(subject_name, *, ca=False, ca_key=None, issuer_name='',
     if ca and not path_length:
         path_length = 1
 
-    extension = x509.BasicConstraints(ca=True, path_length=path_length)
+    extension = x509.BasicConstraints(ca=ca, path_length=path_length)
     utcnow = datetime.datetime.utcnow()
     builder = x509.CertificateBuilder(
         ).issuer_name(
@@ -130,7 +130,7 @@ def build_key_and_cert(subject_name, *, ca=False, ca_key=None, issuer_name='',
             extension, critical=ca
         )
     # Add extension for when it's not a self signed certificate
-    if issuer_name != subject_name or not ca:
+    if issuer_name != subject_name and ca:
         builder = builder.add_extension(
             x509.KeyUsage(
                 key_agreement=False,

--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -28,6 +28,7 @@ import sros2.errors
 _DOMAIN_ID_ENV = 'ROS_DOMAIN_ID'
 _KEYSTORE_DIR_ENV = 'ROS_SECURITY_KEYSTORE'
 
+
 def create_signed_cert(
         keystore_ca_cert_path: pathlib.Path,
         keystore_ca_key_path: pathlib.Path,
@@ -53,7 +54,7 @@ def create_signed_cert(
         **kwargs)
 
     write_key(private_key, key_path)
-    write_cert(cert, cert_path, chain_ca=[ ca_cert ])  # Store the full chain aswell
+    write_cert(cert, cert_path, chain_ca=[ca_cert])  # Store the full chain aswell
 
 
 def create_symlink(*, src: pathlib.Path, dst: pathlib.Path):

--- a/sros2/sros2/keystore/_enclave.py
+++ b/sros2/sros2/keystore/_enclave.py
@@ -140,7 +140,6 @@ def _create_key_and_cert(
         root_ca: pathlib.Path):
     # Load the CA cert and key from disk
     ca_cert = _utilities.load_cert(keystore_ca_cert_path)
-    root_ca_cert = _utilities.load_cert(root_ca)
 
     with open(keystore_ca_key_path, 'rb') as f:
         ca_key = serialization.load_pem_private_key(f.read(), None, cryptography_backend())
@@ -151,4 +150,4 @@ def _create_key_and_cert(
         ca_key=ca_key)
 
     _utilities.write_key(private_key, key_path)
-    _utilities.write_cert(cert, cert_path, chain_ca=[ca_cert, root_ca_cert])
+    _utilities.write_cert(cert, cert_path)

--- a/sros2/sros2/keystore/_keystore.py
+++ b/sros2/sros2/keystore/_keystore.py
@@ -30,7 +30,7 @@ _KS_PRIVATE = 'private'
 _DEFAULT_COMMON_NAME = 'sros2CA'
 
 
-def create_keystore(keystore_path: pathlib.Path, independent_CA=False) -> None:
+def create_keystore(keystore_path: pathlib.Path, split_CA=False) -> None:
     if is_valid_keystore(keystore_path):
         raise sros2.errors.KeystoreExistsError(keystore_path)
 
@@ -65,7 +65,7 @@ def create_keystore(keystore_path: pathlib.Path, independent_CA=False) -> None:
     if not all(x.is_file() for x in required_files):
         _create_ca_key_cert(keystore_ca_key_path, keystore_ca_cert_path)
 
-        if independent_CA:
+        if split_CA:
             # Create independent Permissions and Identity CA
             _create_ca_key_cert(keystore_permissions_ca_key_path, keystore_permissions_ca_cert_path)
             _create_ca_key_cert(keystore_identity_ca_key_path, keystore_identity_ca_cert_path)

--- a/sros2/sros2/keystore/_keystore.py
+++ b/sros2/sros2/keystore/_keystore.py
@@ -67,8 +67,10 @@ def create_keystore(keystore_path: pathlib.Path, split_CA=False) -> None:
 
         if split_CA:
             # Create independent Permissions and Identity CA
-            _create_ca_key_cert(keystore_permissions_ca_key_path, keystore_permissions_ca_cert_path)
-            _create_ca_key_cert(keystore_identity_ca_key_path, keystore_identity_ca_cert_path)
+            _create_ca_key_cert(keystore_permissions_ca_key_path,
+                                keystore_permissions_ca_cert_path)
+            _create_ca_key_cert(keystore_identity_ca_key_path,
+                                keystore_identity_ca_cert_path)
         else:
             # Use the root CA as Permissions and Identity CA
             for path in (keystore_permissions_ca_cert_path, keystore_identity_ca_cert_path):

--- a/sros2/sros2/keystore/_keystore.py
+++ b/sros2/sros2/keystore/_keystore.py
@@ -69,7 +69,7 @@ def create_keystore(keystore_path: pathlib.Path, split_CA=False) -> None:
             # Create independent Permissions and Identity CA
             _utilities.create_signed_cert(keystore_ca_cert_path,
                                           keystore_ca_key_path,
-                                          "IdentityCA",
+                                          'IdentityCA',
                                           keystore_identity_ca_cert_path,
                                           keystore_identity_ca_key_path,
                                           ca=True,
@@ -77,7 +77,7 @@ def create_keystore(keystore_path: pathlib.Path, split_CA=False) -> None:
                                           duration_days=5)
             _utilities.create_signed_cert(keystore_ca_cert_path,
                                           keystore_ca_key_path,
-                                          "PermissionsCA",
+                                          'PermissionsCA',
                                           keystore_permissions_ca_cert_path,
                                           keystore_permissions_ca_key_path,
                                           ca=True,

--- a/sros2/sros2/verb/create_keystore.py
+++ b/sros2/sros2/verb/create_keystore.py
@@ -27,11 +27,15 @@ class CreateKeystoreVerb(VerbExtension):
 
     def add_arguments(self, parser, cli_name) -> None:
         arg = parser.add_argument('ROOT', type=pathlib.Path, help='root path of keystore')
+        arg = parser.add_argument('--independent_CA', action='store_true', default=False,
+                                  help='whether to create new CAs for both \
+                                        Identity and Permissions or use the root CA',
+                                )
         arg.completer = DirectoriesCompleter()
 
     def main(self, *, args) -> int:
         try:
-            sros2.keystore.create_keystore(args.ROOT)
+            sros2.keystore.create_keystore(args.ROOT, args.independent_CA)
         except sros2.errors.SROS2Error as e:
             print(f'Unable to create keystore: {str(e)}', file=sys.stderr)
             return 1

--- a/sros2/sros2/verb/create_keystore.py
+++ b/sros2/sros2/verb/create_keystore.py
@@ -27,15 +27,15 @@ class CreateKeystoreVerb(VerbExtension):
 
     def add_arguments(self, parser, cli_name) -> None:
         arg = parser.add_argument('ROOT', type=pathlib.Path, help='root path of keystore')
-        arg = parser.add_argument('--independent_CA', action='store_true', default=False,
-                                  help='whether to create new CAs for both \
-                                        Identity and Permissions or use the root CA',
+        arg = parser.add_argument('--split-CA', action='store_true', default=False,
+                                  help='splits the Certificate Authority structure to \
+                                    use multiple CAs instead of a single self-signed root CA',
                                 )
         arg.completer = DirectoriesCompleter()
 
     def main(self, *, args) -> int:
         try:
-            sros2.keystore.create_keystore(args.ROOT, args.independent_CA)
+            sros2.keystore.create_keystore(args.ROOT, args.split_CA)
         except sros2.errors.SROS2Error as e:
             print(f'Unable to create keystore: {str(e)}', file=sys.stderr)
             return 1

--- a/sros2/sros2/verb/create_keystore.py
+++ b/sros2/sros2/verb/create_keystore.py
@@ -29,8 +29,7 @@ class CreateKeystoreVerb(VerbExtension):
         arg = parser.add_argument('ROOT', type=pathlib.Path, help='root path of keystore')
         arg = parser.add_argument('--split-CA', action='store_true', default=False,
                                   help='splits the Certificate Authority structure to \
-                                    use multiple CAs instead of a single self-signed root CA',
-                                )
+                                    use multiple CAs instead of a single self-signed root CA')
         arg.completer = DirectoriesCompleter()
 
     def main(self, *, args) -> int:


### PR DESCRIPTION
Ticket https://github.com/ros2/sros2/issues/328

I added a new (optional) flag for the `create_keystore` command: `--split-CA`
This flag changes the Certificate Authorities structure creating two new CAs (Permissions CA and Identity CA) instead of using the same self-signed root CA with symlinks.
This is an optional flag and does not change default behavior.

More details in the ticket https://github.com/ros2/sros2/issues/328


