### PR TITLE
Create new rmw_security_common

### DIFF
--- a/rmw_security_common/CMakeLists.txt
+++ b/rmw_security_common/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rmw_security_common)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+ament_add_default_options()
+
+add_library(${PROJECT_NAME}_library
+  src/security.cpp)
+
+set_target_properties(${PROJECT_NAME}_library
+  PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME}_library
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME}_library
+  PRIVATE "RMW_SECUTIRY_COMMON_BUILDING_LIBRARY")
+
+install(
+  TARGETS ${PROJECT_NAME}_library EXPORT ${PROJECT_NAME}_library
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_libraries(${PROJECT_NAME}_library)
+
+# Export modern CMake targets
+ament_export_targets(${PROJECT_NAME}_library)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gmock REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_gmock(test_security test/test_security.cpp)
+  if(TARGET test_security)
+    target_link_libraries(test_security
+      ${PROJECT_NAME}_library)
+  endif()
+endif()
+
+ament_package()

--- a/rmw_security_common/CMakeLists.txt
+++ b/rmw_security_common/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(${PROJECT_NAME}_library
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME}_library
-  PRIVATE "RMW_SECUTIRY_COMMON_BUILDING_LIBRARY")
+  PRIVATE "RMW_SECURITY_COMMON_BUILDING_LIBRARY")
 
 install(
   TARGETS ${PROJECT_NAME}_library EXPORT ${PROJECT_NAME}_library

--- a/rmw_security_common/include/rmw_security_common/security.hpp
+++ b/rmw_security_common/include/rmw_security_common/security.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_SECUTIRY_COMMON__SECURITY_HPP_
-#define RMW_SECUTIRY_COMMON__SECURITY_HPP_
+#ifndef RMW_SECURITY_COMMON__SECURITY_HPP_
+#define RMW_SECURITY_COMMON__SECURITY_HPP_
 
 #include <string>
 #include <unordered_map>
@@ -84,6 +84,6 @@ bool get_security_files(
   const std::string & secure_root,
   std::unordered_map<std::string, std::string> & result);
 
-}  // namespace rmw_dds_common
+}  // namespace rmw_security_common
 
-#endif  // RMW_SECUTIRY_COMMON__SECURITY_HPP_
+#endif  // RMW_SECURITY_COMMON__SECURITY_HPP_

--- a/rmw_security_common/include/rmw_security_common/security.hpp
+++ b/rmw_security_common/include/rmw_security_common/security.hpp
@@ -1,0 +1,89 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_SECUTIRY_COMMON__SECURITY_HPP_
+#define RMW_SECUTIRY_COMMON__SECURITY_HPP_
+
+#include <string>
+#include <unordered_map>
+
+#include "rmw_security_common/visibility_control.h"
+
+namespace rmw_security_common
+{
+
+/// Get the set of security files in a security enclave.
+/**
+ * This function will look through the passed in 'secure root'
+ * for a set of required filenames that must be in the enclave.
+ * If any of the required filenames are missing, the 'result'
+ * will be empty and the function will return false.
+ * If all of the required filenames are present, then this function
+ * will fill in the 'result' map with a key-value pair of
+ * friendy name -> filename.  If the prefix is not empty, then
+ * the prefix will be applied to the filename.
+ *
+ * The friendly names that this function will currently fill in are:
+ *   IDENTITY_CA
+ *   CERTIFICATE
+ *   PRIVATE_KEY
+ *   PERMISSIONS_CA
+ *   GOVERNANCE
+ *   PERMISSIONS
+ *
+ * \param[in]  prefix An optional prefix to apply to the filenames when storing them.
+ * \param[in]  secure_root The path to the security enclave to look at.
+ * \param[out] result The map where the friendly name -> filename pairs are stored.
+ * \return `true` if all required files exist in the security enclave, `false` otherwise.
+ */
+RMW_SECURITY_COMMON_PUBLIC
+bool get_security_files(
+  const std::string & prefix, const std::string & secure_root,
+  std::unordered_map<std::string, std::string> & result);
+
+/// Get the set of security files in a security enclave.
+/**
+ * This function will look through the passed in 'secure root'
+ * for a set of required filenames that must be in the enclave.
+ * If any of the required filenames are missing, the 'result'
+ * will be empty and the function will return false.
+ * If all of the required filenames are present, then this function
+ * will fill in the 'result' map with a key-value pair of
+ * friendy name -> filename.  If the prefix is not empty, then
+ * the prefix will be applied to the filename.
+ *
+ * The friendly names that this function will currently fill in are:
+ *   IDENTITY_CA
+ *   CERTIFICATE
+ *   PRIVATE_KEY
+ *   PERMISSIONS_CA
+ *   GOVERNANCE
+ *   PERMISSIONS
+ *
+ * \param[in]  supports_pkcs11 Whether the RMW has support for PKCS#11 URIs.
+ * \param[in]  prefix An optional prefix to apply to the filenames when storing them.
+ * \param[in]  secure_root The path to the security enclave to look at.
+ * \param[out] result The map where the friendly name -> filename pairs are stored.
+ * \return `true` if all required files exist in the security enclave, `false` otherwise.
+ */
+RMW_SECURITY_COMMON_PUBLIC
+bool get_security_files(
+  bool supports_pkcs11,
+  const std::string & prefix,
+  const std::string & secure_root,
+  std::unordered_map<std::string, std::string> & result);
+
+}  // namespace rmw_dds_common
+
+#endif  // RMW_SECUTIRY_COMMON__SECURITY_HPP_

--- a/rmw_security_common/include/rmw_security_common/visibility_control.h
+++ b/rmw_security_common/include/rmw_security_common/visibility_control.h
@@ -1,0 +1,58 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_SECURITY_COMMON__VISIBILITY_CONTROL_H_
+#define RMW_SECURITY_COMMON__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define RMW_SECURITY_COMMON_EXPORT __attribute__ ((dllexport))
+    #define RMW_SECURITY_COMMON_IMPORT __attribute__ ((dllimport))
+  #else
+    #define RMW_SECURITY_COMMON_EXPORT __declspec(dllexport)
+    #define RMW_SECURITY_COMMON_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef RMW_SECURITY_COMMON_BUILDING_LIBRARY
+    #define RMW_SECURITY_COMMON_PUBLIC RMW_SECURITY_COMMON_EXPORT
+  #else
+    #define RMW_SECURITY_COMMON_PUBLIC RMW_SECURITY_COMMON_IMPORT
+  #endif
+  #define RMW_SECURITY_COMMON_PUBLIC_TYPE RMW_SECURITY_COMMON_PUBLIC
+  #define RMW_SECURITY_COMMON_LOCAL
+#else
+  #define RMW_SECURITY_COMMON_EXPORT __attribute__ ((visibility("default")))
+  #define RMW_SECURITY_COMMON_IMPORT
+  #if __GNUC__ >= 4
+    #define RMW_SECURITY_COMMON_PUBLIC __attribute__ ((visibility("default")))
+    #define RMW_SECURITY_COMMON_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define RMW_SECURITY_COMMON_PUBLIC
+    #define RMW_SECURITY_COMMON_LOCAL
+  #endif
+  #define RMW_SECURITY_COMMON_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RMW_SECURITY_COMMON__VISIBILITY_CONTROL_H_

--- a/rmw_security_common/package.xml
+++ b/rmw_security_common/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rmw_security_common</name>
+  <version>0.15.1</version>
+  <description>Define a common rmw secutiry utils</description>
+
+  <maintainer email="alejandro@openrobotics.org">Alejandro Hernandez Cordero</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="alejandro@openrobotics.org">Alejandro Hernandez Cordero</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rmw_security_common/src/security.cpp
+++ b/rmw_security_common/src/security.cpp
@@ -1,0 +1,150 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <string>
+#include <utility>
+#include <unordered_map>
+#include <vector>
+
+#include "rmw_security_common/security.hpp"
+
+namespace rmw_security_common
+{
+
+// Processor for security attributes with FILE URI
+static bool process_file_uri_security_file(
+  bool /*supports_pkcs11*/,
+  const std::string & prefix,
+  const std::filesystem::path & full_path,
+  std::string & result)
+{
+  if (!std::filesystem::is_regular_file(full_path)) {
+    return false;
+  }
+  result = prefix + full_path.generic_string();
+  return true;
+}
+
+// Processor for security attributes with PKCS#11 URI
+static bool process_pkcs_uri_security_file(
+  bool supports_pkcs11,
+  const std::string & /*prefix*/,
+  const std::filesystem::path & full_path,
+  std::string & result)
+{
+  if (!supports_pkcs11) {
+    return false;
+  }
+
+  const std::string p11_prefix("pkcs11:");
+
+  std::ifstream ifs(full_path);
+  if (!ifs.is_open()) {
+    return false;
+  }
+
+  if (!(ifs >> result)) {
+    return false;
+  }
+  if (result.find(p11_prefix) != 0) {
+    return false;
+  }
+
+  return true;
+}
+
+bool get_security_files(
+  const std::string & prefix, const std::string & secure_root,
+  std::unordered_map<std::string, std::string> & result)
+{
+  return get_security_files(false, prefix, secure_root, result);
+}
+
+bool get_security_files(
+  bool supports_pkcs11,
+  const std::string & prefix,
+  const std::string & secure_root,
+  std::unordered_map<std::string, std::string> & result)
+{
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  using std::placeholders::_3;
+  using std::placeholders::_4;
+  using security_file_processor =
+    std::function<bool (bool, const std::string &, const std::filesystem::path &, std::string &)>;
+  using processor_vector =
+    std::vector<std::pair<std::string, security_file_processor>>;
+
+  // Key: the security attribute
+  // Value: ordered sequence of pairs. Each pair contains one possible file name
+  //        for the attribute and the corresponding processor method
+  // Pairs are ordered by priority: the first one matching is used.
+  const std::unordered_map<std::string, processor_vector> required_files{
+    {"IDENTITY_CA", {
+        {"identity_ca.cert.p11", std::bind(process_pkcs_uri_security_file, _1, _2, _3, _4)},
+        {"identity_ca.cert.pem", std::bind(process_file_uri_security_file, _1, _2, _3, _4)}}},
+    {"CERTIFICATE", {
+        {"cert.p11", std::bind(process_pkcs_uri_security_file, _1, _2, _3, _4)},
+        {"cert.pem", std::bind(process_file_uri_security_file, _1, _2, _3, _4)}}},
+    {"PRIVATE_KEY", {
+        {"key.p11", std::bind(process_pkcs_uri_security_file, _1, _2, _3, _4)},
+        {"key.pem", std::bind(process_file_uri_security_file, _1, _2, _3, _4)}}},
+    {"PERMISSIONS_CA", {
+        {"permissions_ca.cert.p11", std::bind(process_pkcs_uri_security_file, _1, _2, _3, _4)},
+        {"permissions_ca.cert.pem", std::bind(process_file_uri_security_file, _1, _2, _3, _4)}}},
+    {"GOVERNANCE", {
+        {"governance.p7s", std::bind(process_file_uri_security_file, _1, _2, _3, _4)}}},
+    {"PERMISSIONS", {
+        {"permissions.p7s", std::bind(process_file_uri_security_file, _1, _2, _3, _4)}}},
+  };
+
+  const std::unordered_map<std::string, std::string> optional_files{
+    {"CRL", "crl.pem"},
+  };
+
+  for (const std::pair<const std::string,
+    std::vector<std::pair<std::string, security_file_processor>>> & el : required_files)
+  {
+    std::string attribute_value;
+    bool processed = false;
+    for (auto & proc : el.second) {
+      std::filesystem::path full_path(secure_root);
+      full_path /= proc.first;
+      if (proc.second(supports_pkcs11, prefix, full_path, attribute_value)) {
+        processed = true;
+        break;
+      }
+    }
+    if (!processed) {
+      result.clear();
+      return false;
+    }
+    result[el.first] = attribute_value;
+  }
+
+  for (const std::pair<const std::string, std::string> & el : optional_files) {
+    std::filesystem::path full_path(secure_root);
+    full_path /= el.second;
+    if (std::filesystem::is_regular_file(full_path)) {
+      result[el.first] = prefix + full_path.generic_string();
+    }
+  }
+
+  return true;
+}
+
+}  // namespace rmw_dds_common

--- a/rmw_security_common/src/security.cpp
+++ b/rmw_security_common/src/security.cpp
@@ -147,4 +147,4 @@ bool get_security_files(
   return true;
 }
 
-}  // namespace rmw_dds_common
+}  // namespace rmw_security_common

--- a/rmw_security_common/test/test_security.cpp
+++ b/rmw_security_common/test/test_security.cpp
@@ -310,7 +310,8 @@ TEST_P(test_security, only_pkcs11_present)
 
   if (GetParam()) {
     ASSERT_TRUE(
-      rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(), security_files));
+      rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(),
+      security_files));
     EXPECT_EQ(
       security_files["IDENTITY_CA"],
       "pkcs11://identity_ca.cert.p11");
@@ -331,7 +332,8 @@ TEST_P(test_security, only_pkcs11_present)
       std::filesystem::path("./test_folder/permissions.p7s").generic_string());
   } else {
     ASSERT_FALSE(
-      rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(), security_files));
+      rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(),
+      security_files));
     ASSERT_EQ(security_files.size(), 0UL);
   }
 }

--- a/rmw_security_common/test/test_security.cpp
+++ b/rmw_security_common/test/test_security.cpp
@@ -1,0 +1,405 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <array>
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+
+#include "gtest/gtest.h"
+
+#include "rmw_security_common/security.hpp"
+
+// Utility to write test content on required files
+template<size_t N>
+static void write_test_content(const std::array<std::string, N> & required_files)
+{
+  for (const std::string & filename : required_files) {
+    std::filesystem::path full_path = std::filesystem::path("./test_folder") / filename;
+    std::ofstream output_buffer{full_path.generic_string()};
+    output_buffer << "test";
+    ASSERT_TRUE(std::filesystem::exists(full_path));
+  }
+}
+
+// Utility to write pkcs11 content on required files
+template<size_t N>
+static void write_test_pkcs11_content(const std::array<std::string, N> & pkcs11_files)
+{
+  for (const std::string & filename : pkcs11_files) {
+    std::filesystem::path full_path = std::filesystem::path("./test_folder") / filename;
+    std::ofstream output_buffer{full_path.generic_string()};
+    output_buffer << "pkcs11://" << filename;
+    ASSERT_TRUE(std::filesystem::exists(full_path));
+  }
+}
+
+class test_security : public ::testing::TestWithParam<bool> {};
+
+TEST_P(test_security, files_exist_no_prefix)
+{
+  std::filesystem::path dir = std::filesystem::path("./test_folder");
+  std::filesystem::remove_all(dir);
+  EXPECT_TRUE(std::filesystem::create_directories(dir));
+  EXPECT_TRUE(std::filesystem::exists(dir));
+  EXPECT_TRUE(std::filesystem::is_directory(dir));
+
+  std::array<std::string, 6> required_files = {
+    "identity_ca.cert.pem", "cert.pem", "key.pem",
+    "permissions_ca.cert.pem", "governance.p7s", "permissions.p7s"
+  };
+  write_test_content(required_files);
+
+  std::unordered_map<std::string, std::string> security_files;
+  ASSERT_TRUE(
+    rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(), security_files));
+
+  EXPECT_EQ(
+    security_files["IDENTITY_CA"],
+    std::filesystem::path("./test_folder/identity_ca.cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["CERTIFICATE"],
+    std::filesystem::path("./test_folder/cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["PRIVATE_KEY"],
+    std::filesystem::path("./test_folder/key.pem").generic_string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS_CA"],
+    std::filesystem::path("./test_folder/permissions_ca.cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["GOVERNANCE"],
+    std::filesystem::path("./test_folder/governance.p7s").generic_string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS"],
+    std::filesystem::path("./test_folder/permissions.p7s").generic_string());
+}
+
+TEST_P(test_security, files_exist_with_prefix)
+{
+  std::filesystem::path dir = std::filesystem::path("./test_folder");
+  std::filesystem::remove_all(dir);
+  EXPECT_TRUE(std::filesystem::create_directories(dir));
+  EXPECT_TRUE(std::filesystem::exists(dir));
+  EXPECT_TRUE(std::filesystem::is_directory(dir));
+
+  std::array<std::string, 6> required_files = {
+    "identity_ca.cert.pem", "cert.pem", "key.pem",
+    "permissions_ca.cert.pem", "governance.p7s", "permissions.p7s"
+  };
+  write_test_content(required_files);
+
+  std::unordered_map<std::string, std::string> security_files;
+  ASSERT_TRUE(
+    rmw_security_common::get_security_files(
+      GetParam(), "file://", dir.generic_string(), security_files));
+
+  EXPECT_EQ(
+    security_files["IDENTITY_CA"],
+    "file://" + std::filesystem::path("./test_folder/identity_ca.cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["CERTIFICATE"],
+    "file://" + std::filesystem::path("./test_folder/cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["PRIVATE_KEY"],
+    "file://" + std::filesystem::path("./test_folder/key.pem").generic_string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS_CA"],
+    "file://" + std::filesystem::path("./test_folder/permissions_ca.cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["GOVERNANCE"],
+    "file://" + std::filesystem::path("./test_folder/governance.p7s").generic_string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS"],
+    "file://" + std::filesystem::path("./test_folder/permissions.p7s").generic_string());
+}
+
+TEST_P(test_security, file_missing)
+{
+  std::filesystem::path dir = std::filesystem::path("./test_folder");
+  std::filesystem::remove_all(dir);
+  EXPECT_TRUE(std::filesystem::create_directories(dir));
+  EXPECT_TRUE(std::filesystem::exists(dir));
+  EXPECT_TRUE(std::filesystem::is_directory(dir));
+
+  std::array<std::string, 5> required_files = {
+    "identity_ca.cert.pem", "cert.pem", "key.pem",
+    "permissions_ca.cert.pem", "governance.p7s"
+  };
+  write_test_content(required_files);
+
+  std::unordered_map<std::string, std::string> security_files;
+  ASSERT_FALSE(
+    rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(), security_files));
+  ASSERT_EQ(security_files.size(), 0UL);
+}
+
+TEST_P(test_security, optional_file_exist)
+{
+  std::filesystem::path dir = std::filesystem::path("./test_folder");
+  std::filesystem::remove_all(dir);
+  EXPECT_TRUE(std::filesystem::create_directories(dir));
+  EXPECT_TRUE(std::filesystem::exists(dir));
+  EXPECT_TRUE(std::filesystem::is_directory(dir));
+
+  std::array<std::string, 7> required_files = {
+    "identity_ca.cert.pem", "cert.pem", "key.pem",
+    "permissions_ca.cert.pem", "governance.p7s", "permissions.p7s", "crl.pem",
+  };
+  write_test_content(required_files);
+
+  std::unordered_map<std::string, std::string> security_files;
+  ASSERT_TRUE(
+    rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(), security_files));
+
+  EXPECT_EQ(
+    security_files["IDENTITY_CA"],
+    std::filesystem::path("./test_folder/identity_ca.cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["CERTIFICATE"],
+    std::filesystem::path("./test_folder/cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["PRIVATE_KEY"],
+    std::filesystem::path("./test_folder/key.pem").generic_string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS_CA"],
+    std::filesystem::path("./test_folder/permissions_ca.cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["GOVERNANCE"],
+    std::filesystem::path("./test_folder/governance.p7s").generic_string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS"],
+    std::filesystem::path("./test_folder/permissions.p7s").generic_string());
+
+  EXPECT_EQ(
+    security_files["CRL"],
+    std::filesystem::path("./test_folder/crl.pem").generic_string());
+}
+
+TEST_P(test_security, wrong_pkcs11_file_ignored)
+{
+  std::filesystem::path dir = std::filesystem::path("./test_folder");
+  std::filesystem::remove_all(dir);
+  EXPECT_TRUE(std::filesystem::create_directories(dir));
+  EXPECT_TRUE(std::filesystem::exists(dir));
+  EXPECT_TRUE(std::filesystem::is_directory(dir));
+
+  std::array<std::string, 10> required_files = {
+    "identity_ca.cert.pem", "cert.pem", "key.pem",
+    "permissions_ca.cert.pem", "governance.p7s", "permissions.p7s",
+    "identity_ca.cert.p11", "cert.p11", "key.p11",
+    "permissions_ca.cert.p11"
+  };
+  write_test_content(required_files);
+
+  std::unordered_map<std::string, std::string> security_files;
+  ASSERT_TRUE(
+    rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(), security_files));
+
+  EXPECT_EQ(
+    security_files["IDENTITY_CA"],
+    std::filesystem::path("./test_folder/identity_ca.cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["CERTIFICATE"],
+    std::filesystem::path("./test_folder/cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["PRIVATE_KEY"],
+    std::filesystem::path("./test_folder/key.pem").generic_string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS_CA"],
+    std::filesystem::path("./test_folder/permissions_ca.cert.pem").generic_string());
+  EXPECT_EQ(
+    security_files["GOVERNANCE"],
+    std::filesystem::path("./test_folder/governance.p7s").generic_string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS"],
+    std::filesystem::path("./test_folder/permissions.p7s").generic_string());
+}
+
+TEST_P(test_security, pkcs11_support_check)
+{
+  std::filesystem::path dir = std::filesystem::path("./test_folder");
+  std::filesystem::remove_all(dir);
+  EXPECT_TRUE(std::filesystem::create_directories(dir));
+  EXPECT_TRUE(std::filesystem::exists(dir));
+  EXPECT_TRUE(std::filesystem::is_directory(dir));
+
+  std::array<std::string, 6> required_files = {
+    "identity_ca.cert.pem", "cert.pem", "key.pem",
+    "permissions_ca.cert.pem", "governance.p7s", "permissions.p7s"
+  };
+  write_test_content(required_files);
+
+  std::array<std::string, 4> pkcs11_files = {
+    "identity_ca.cert.p11", "cert.p11", "key.p11",
+    "permissions_ca.cert.p11"
+  };
+  write_test_pkcs11_content(pkcs11_files);
+
+  std::unordered_map<std::string, std::string> security_files;
+  ASSERT_TRUE(
+    rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(), security_files));
+
+  if (GetParam()) {
+    EXPECT_EQ(
+      security_files["IDENTITY_CA"],
+      "pkcs11://identity_ca.cert.p11");
+    EXPECT_EQ(
+      security_files["CERTIFICATE"],
+      "pkcs11://cert.p11");
+    EXPECT_EQ(
+      security_files["PRIVATE_KEY"],
+      "pkcs11://key.p11");
+    EXPECT_EQ(
+      security_files["PERMISSIONS_CA"],
+      "pkcs11://permissions_ca.cert.p11");
+  } else {
+    EXPECT_EQ(
+      security_files["IDENTITY_CA"],
+      std::filesystem::path("./test_folder/identity_ca.cert.pem").generic_string());
+    EXPECT_EQ(
+      security_files["CERTIFICATE"],
+      std::filesystem::path("./test_folder/cert.pem").generic_string());
+    EXPECT_EQ(
+      security_files["PRIVATE_KEY"],
+      std::filesystem::path("./test_folder/key.pem").generic_string());
+    EXPECT_EQ(
+      security_files["PERMISSIONS_CA"],
+      std::filesystem::path("./test_folder/permissions_ca.cert.pem").generic_string());
+  }
+  EXPECT_EQ(
+    security_files["GOVERNANCE"],
+    std::filesystem::path("./test_folder/governance.p7s").generic_string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS"],
+    std::filesystem::path("./test_folder/permissions.p7s").generic_string());
+}
+
+TEST_P(test_security, only_pkcs11_present)
+{
+  std::filesystem::path dir = std::filesystem::path("./test_folder");
+  std::filesystem::remove_all(dir);
+  EXPECT_TRUE(std::filesystem::create_directories(dir));
+  EXPECT_TRUE(std::filesystem::exists(dir));
+  EXPECT_TRUE(std::filesystem::is_directory(dir));
+
+  std::array<std::string, 2> required_files = {
+    "governance.p7s", "permissions.p7s"
+  };
+  write_test_content(required_files);
+
+  std::array<std::string, 4> pkcs11_files = {
+    "identity_ca.cert.p11", "cert.p11", "key.p11",
+    "permissions_ca.cert.p11"
+  };
+  write_test_pkcs11_content(pkcs11_files);
+
+  std::unordered_map<std::string, std::string> security_files;
+
+  if (GetParam()) {
+    ASSERT_TRUE(
+      rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(), security_files));
+    EXPECT_EQ(
+      security_files["IDENTITY_CA"],
+      "pkcs11://identity_ca.cert.p11");
+    EXPECT_EQ(
+      security_files["CERTIFICATE"],
+      "pkcs11://cert.p11");
+    EXPECT_EQ(
+      security_files["PRIVATE_KEY"],
+      "pkcs11://key.p11");
+    EXPECT_EQ(
+      security_files["PERMISSIONS_CA"],
+      "pkcs11://permissions_ca.cert.p11");
+    EXPECT_EQ(
+      security_files["GOVERNANCE"],
+      std::filesystem::path("./test_folder/governance.p7s").generic_string());
+    EXPECT_EQ(
+      security_files["PERMISSIONS"],
+      std::filesystem::path("./test_folder/permissions.p7s").generic_string());
+  } else {
+    ASSERT_FALSE(
+      rmw_security_common::get_security_files(GetParam(), "", dir.generic_string(), security_files));
+    ASSERT_EQ(security_files.size(), 0UL);
+  }
+}
+
+TEST_P(test_security, pkcs11_prefix_ignored)
+{
+  std::filesystem::path dir = std::filesystem::path("./test_folder");
+  std::filesystem::remove_all(dir);
+  EXPECT_TRUE(std::filesystem::create_directories(dir));
+  EXPECT_TRUE(std::filesystem::exists(dir));
+  EXPECT_TRUE(std::filesystem::is_directory(dir));
+
+  std::array<std::string, 6> required_files = {
+    "identity_ca.cert.pem", "cert.pem", "key.pem",
+    "permissions_ca.cert.pem", "governance.p7s", "permissions.p7s"
+  };
+  write_test_content(required_files);
+
+  std::array<std::string, 4> pkcs11_files = {
+    "identity_ca.cert.p11", "cert.p11", "key.p11",
+    "permissions_ca.cert.p11"
+  };
+  write_test_pkcs11_content(pkcs11_files);
+
+  std::unordered_map<std::string, std::string> security_files;
+  ASSERT_TRUE(
+    rmw_security_common::get_security_files(
+      GetParam(), "file://", dir.generic_string(), security_files));
+
+  if (GetParam()) {
+    EXPECT_EQ(
+      security_files["IDENTITY_CA"],
+      "pkcs11://identity_ca.cert.p11");
+    EXPECT_EQ(
+      security_files["CERTIFICATE"],
+      "pkcs11://cert.p11");
+    EXPECT_EQ(
+      security_files["PRIVATE_KEY"],
+      "pkcs11://key.p11");
+    EXPECT_EQ(
+      security_files["PERMISSIONS_CA"],
+      "pkcs11://permissions_ca.cert.p11");
+  } else {
+    EXPECT_EQ(
+      security_files["IDENTITY_CA"],
+      "file://" + std::filesystem::path("./test_folder/identity_ca.cert.pem").generic_string());
+    EXPECT_EQ(
+      security_files["CERTIFICATE"],
+      "file://" + std::filesystem::path("./test_folder/cert.pem").generic_string());
+    EXPECT_EQ(
+      security_files["PRIVATE_KEY"],
+      "file://" + std::filesystem::path("./test_folder/key.pem").generic_string());
+    EXPECT_EQ(
+      security_files["PERMISSIONS_CA"],
+      "file://" + std::filesystem::path("./test_folder/permissions_ca.cert.pem").generic_string());
+  }
+  EXPECT_EQ(
+    security_files["GOVERNANCE"],
+    "file://" + std::filesystem::path("./test_folder/governance.p7s").generic_string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS"],
+    "file://" + std::filesystem::path("./test_folder/permissions.p7s").generic_string());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  test_security,
+  test_security,
+  ::testing::Values(false, true),
+  [](const testing::TestParamInfo<bool> & info) {
+    return info.param ? "with_pkcs11_support" : "with_no_pkcs11_support";
+  });


### PR DESCRIPTION
the new `rmw_zenoh_cpp` has an open PR to include certificates using the `--enclave` argument. This requires to use `rmw_dds_common::get_security_files` which is not a dds unique utility. 

The idea with new package is to include here all the security common things.

