### PR TITLE
[tests][mypy] add type hint to rmw_implementation and use_daemon to fix mypy

### DIFF
--- a/sros2/test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py
+++ b/sros2/test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py
@@ -33,7 +33,7 @@ MAX_DISCOVERY_DELAY = 4.0  # seconds
 
 
 def generate_sros2_cli_test_description(
-    fixture_actions, rmw_implementation, use_daemon
+    fixture_actions, rmw_implementation: str, use_daemon: bool
 ) -> LaunchDescription:
     additional_env = {'RMW_IMPLEMENTATION': rmw_implementation}
     if use_daemon:


### PR DESCRIPTION
CI has been failing for the last two weeks with the following error.
This PR attemps to fix it:

```
  =================================== FAILURES ===================================
  __________________________________ test_mypy ___________________________________
  test/test_mypy.py:31: in test_mypy
      assert main(argv=[]) == 0, 'Found errors'
  E   AssertionError: Found errors
  E   assert 1 == 0
  E    +  where 1 = main(argv=[])
  ----------------------------- Captured stdout call -----------------------------
  
  48 files checked
  3 errors
  test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py: note: In function "generate_sros2_cli_test_description":
  test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py:45:28: error: Argument "additional_env" to "ExecuteProcess" has incompatible type "dict[str, Any]"; expected "dict[str | Substitution | Iterable[str | Substitution], str | Substitution | Iterable[str | Substitution]] | None"  [arg-type]
  test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py:53:28: error: Argument "additional_env" to "ExecuteProcess" has incompatible type "dict[str, Any]"; expected "dict[str | Substitution | Iterable[str | Substitution], str | Substitution | Iterable[str | Substitution]] | None"  [arg-type]
  Found 2 errors in 1 file (checked 48 source files)
```