### PR TITLE
fastrtps is now renamed into fastdds officially for ROS 2.

### DIFF
--- a/SROS2_Linux.md
+++ b/SROS2_Linux.md
@@ -23,7 +23,7 @@ First install ROS 2 from source following [these instructions](https://docs.ros.
 
 Note: Fast-RTPS requires an additional CMake flag to build the security plugins so the colcon invocation needs to be modified to pass:
 ```bash
-colcon build --symlink-install --cmake-args -DSECURITY=ON --packages-select fastrtps rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp rmw_fastrtps_shared_cpp
+colcon build --symlink-install --cmake-args -DSECURITY=ON --packages-select fastdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp rmw_fastrtps_shared_cpp
 ```
 
 ### Additional configuration for RTI Connext

--- a/SROS2_MacOS.md
+++ b/SROS2_MacOS.md
@@ -41,7 +41,7 @@ Install ROS 2 from source following [these instructions](https://docs.ros.org/en
 
 Note: Fast-RTPS requires an additional CMake flag to build the security plugins so the colcon invocation needs to be modified to pass:
 ```bash
-colcon build --symlink-install --cmake-args -DSECURITY=ON --packages-select fastrtps rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp rmw_fastrtps_shared_cpp
+colcon build --symlink-install --cmake-args -DSECURITY=ON --packages-select fastdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp rmw_fastrtps_shared_cpp
 ```
 
 Setup your environment:

--- a/SROS2_Windows.md
+++ b/SROS2_Windows.md
@@ -14,7 +14,7 @@ Please follow [these instructions](https://docs.ros.org/en/rolling/Installation/
 
 To build the ROS 2 code with security extensions, call:
 ```bat
-colcon build --cmake-args -DSECURITY=ON --packages-select fastrtps rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp rmw_fastrtps_shared_cpp
+colcon build --cmake-args -DSECURITY=ON --packages-select fastdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp rmw_fastrtps_shared_cpp
 ```
 
 ### Install OpenSSL


### PR DESCRIPTION
along with https://github.com/ros2/ros2_documentation/pull/5482

> [!NOTE]
> We need to backport this to kilted.