### PR TITLE
Update _utilities.py to pass instance not class of ec.SECP256R1

### DIFF
--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -71,7 +71,7 @@ def build_key_and_cert(subject_name, *, ca=False, ca_key=None, issuer_name=''):
         issuer_name = subject_name
 
     # DDS-Security section 9.3.1 calls for prime256v1, for which SECP256R1 is an alias
-    private_key = ec.generate_private_key(ec.SECP256R1, cryptography_backend())
+    private_key = ec.generate_private_key(ec.SECP256R1(), cryptography_backend())
     if not ca_key:
         ca_key = private_key
 


### PR DESCRIPTION
## Description

The following line in sros2/sros2/_utilities.py causes a runtime error when creating a keystore:
https://github.com/ros2/sros2/blob/jazzy/sros2/sros2/_utilities.py#L74

```
INFO: Running command line: bazel-bin/ros2/ros2_security create_keystore /tmp/MY_ENCLAVE2
/home/torc/.cache/bazel/_bazel_torc/9aa7afc3a0e2498fab67e6e6e7243812/execroot/rules_ros2/bazel-out/k8-opt/bin/ros2/ros2_security.runfiles/sros2/sros2/sros2/_utilities.py:74: CryptographyDeprecationWarning: Curve argument must be an instance of an EllipticCurve class. Did you pass a class by mistake? This will be an exception in a future version of cryptography
  private_key = ec.generate_private_key(ec.SECP256R1, cryptography_backend())
```
My build environment uses openssl 3.3.1

The issue was flagged in another repository here:
https://github.com/web-push-libs/vapid/issues/105

The fix is simple enough:

```
-    private_key = ec.generate_private_key(ec.SECP256R1, cryptography_backend())
+    private_key = ec.generate_private_key(ec.SECP256R1(), cryptography_backend())
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #348 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
