### PR TITLE
[CI] rti-connext-6.0.1 rosdep key is obsolete on rolling and already ignored by the action itself

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
         apt-get -qq install -y curl libasio-dev libssl-dev libtinyxml2-dev python3-colcon-coveragepy-result
     - uses: ros-tooling/action-ros-ci@v0.4
       with:
-        rosdep-skip-keys: rti-connext-dds-6.0.1
         package-name: |
           sros2
           sros2_cmake


### PR DESCRIPTION
## Description

Deduplicate rosdep key ignored twice
Upstream action rosdep key ignorance: https://github.com/ros-tooling/action-ros-ci/blob/72c4876bb964d2ed75b4886c49e780b3f313152c/src/action-ros-ci.ts#L204

Fixes # (issue)

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
