### PR TITLE
Clean up isolated ros2 daemon process for tests.

### DIFF
--- a/sros2/test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py
+++ b/sros2/test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py
@@ -15,8 +15,11 @@
 import argparse
 import contextlib
 import time
+from typing import cast
 import unittest
 
+
+from launch import Action
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 from launch.actions import RegisterEventHandler
@@ -44,7 +47,7 @@ def generate_sros2_cli_test_description(
     additional_env = get_rmw_additional_env(rmw_implementation)
     set_env_actions = [SetEnvironmentVariable(k, v) for k, v in additional_env.items()]
     # Build shutdown actions based on whether daemon is used
-    shutdown_actions = []
+    shutdown_actions: list[Action] = []
     if use_daemon:
         # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
         shutdown_actions = [
@@ -52,7 +55,7 @@ def generate_sros2_cli_test_description(
                 cmd=['ros2', 'daemon', 'stop'],
                 name='daemon-stop-isolated',
                 # Use the same isolated environment
-                additional_env=dict(additional_env),
+                additional_env=cast(dict, additional_env),
             ),
         ]
     shutdown_actions.append(ResetEnvironment())

--- a/sros2/test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py
+++ b/sros2/test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py
@@ -43,6 +43,19 @@ def generate_sros2_cli_test_description(
 ) -> LaunchDescription:
     additional_env = get_rmw_additional_env(rmw_implementation)
     set_env_actions = [SetEnvironmentVariable(k, v) for k, v in additional_env.items()]
+    # Build shutdown actions based on whether daemon is used
+    shutdown_actions = []
+    if use_daemon:
+        # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+        shutdown_actions = [
+            ExecuteProcess(
+                cmd=['ros2', 'daemon', 'stop'],
+                name='daemon-stop-isolated',
+                # Use the same isolated environment
+                additional_env=dict(additional_env),
+            ),
+        ]
+    shutdown_actions.append(ResetEnvironment())
     if use_daemon:
         # Start daemon.
         fixture_actions = [ExecuteProcess(
@@ -53,17 +66,7 @@ def generate_sros2_cli_test_description(
     fixture_actions = [
         *set_env_actions,
         EnableRmwIsolation(),
-        RegisterEventHandler(OnShutdown(on_shutdown=[
-            # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
-            ExecuteProcess(
-                cmd=['ros2', 'daemon', 'stop'],
-                name='daemon-stop-isolated',
-                # Use the same isolated environment
-                additional_env=dict(additional_env),
-            ),
-            # This must be done after stopping the daemon in the isolated environment
-            ResetEnvironment(),
-        ])),
+        RegisterEventHandler(OnShutdown(on_shutdown=shutdown_actions)),
         *fixture_actions,
     ]
     return LaunchDescription([

--- a/sros2/test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py
+++ b/sros2/test/sros2/commands/security/verbs/utilities/sros2_cli_test_case.py
@@ -19,7 +19,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 
 import launch_testing
 import launch_testing.asserts
@@ -50,6 +53,17 @@ def generate_sros2_cli_test_description(
     fixture_actions = [
         *set_env_actions,
         EnableRmwIsolation(),
+        RegisterEventHandler(OnShutdown(on_shutdown=[
+            # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+            ExecuteProcess(
+                cmd=['ros2', 'daemon', 'stop'],
+                name='daemon-stop-isolated',
+                # Use the same isolated environment
+                additional_env=dict(additional_env),
+            ),
+            # This must be done after stopping the daemon in the isolated environment
+            ResetEnvironment(),
+        ])),
         *fixture_actions,
     ]
     return LaunchDescription([


### PR DESCRIPTION
## Description

(hopefully) closes https://github.com/ros2/sros2/issues/374

although i do not actually see the direct root cause of this, this PR should be able to fix the unexpected situation that generates the zombie ros2daemon process after the test.

before: each rmw implementation leaves the ros2daemon zombie process with some domain id.
after: it makes sure to clean up the ros2daemon process spawned by the test initialization at the exiting the test scenario.

this could be the reason that some tests cannot find the endpoints with calling `wait_for` method.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

No, just test integrity.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No,

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

We also have similar fixes for ros2cli: https://github.com/ros2/ros2cli/pull/1098

<!--
If applicable, provide any additional context or details about the changes.
-->
