### PR TITLE
Fix `load_file_into_BIO: File could not be found, opened or is empty` error on Windows

### DIFF
--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -39,8 +39,7 @@ def create_symlink(*, src: pathlib.Path, dst: pathlib.Path):
         os.remove(dst)
     if platform.system() == 'Windows':
         # Resolve the absolute path for the source file
-        actual_src = dst.parent.joinpath(src).resolve()
-        
+        actual_src = dst.parent.joinpath(src).resolve() 
         try:
             # Create a hard link. To OpenSSL, this looks like a physical file.
             os.link(actual_src, dst)

--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -16,6 +16,8 @@
 import datetime
 import os
 import pathlib
+import platform
+import shutil
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend as cryptography_backend
@@ -36,6 +38,20 @@ def create_symlink(*, src: pathlib.Path, dst: pathlib.Path):
             return
         os.remove(dst)
     os.symlink(src, dst)
+    if platform.system() == 'Windows':
+        # Resolve the absolute path for the source file
+        actual_src = dst.parent.joinpath(src).resolve()
+        
+        try:
+            # Create a hard link. To OpenSSL, this looks like a physical file.
+            os.link(actual_src, dst)
+        except OSError:
+            # Failsafe: If the CI environment mounts enclaves on a different volume
+            # than the public keystore, hard links will fail. Fallback to copy.
+            shutil.copy2(actual_src, dst)
+    else:
+        # Retain standard, lightweight symlink behavior for Unix/macOS
+        os.symlink(src, dst)
 
 
 def domain_id() -> str:

--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -39,7 +39,7 @@ def create_symlink(*, src: pathlib.Path, dst: pathlib.Path):
         os.remove(dst)
     if platform.system() == 'Windows':
         # Resolve the absolute path for the source file
-        actual_src = dst.parent.joinpath(src).resolve() 
+        actual_src = dst.parent.joinpath(src).resolve()
         try:
             # Create a hard link. To OpenSSL, this looks like a physical file.
             os.link(actual_src, dst)

--- a/sros2/sros2/_utilities.py
+++ b/sros2/sros2/_utilities.py
@@ -37,7 +37,6 @@ def create_symlink(*, src: pathlib.Path, dst: pathlib.Path):
         if dst.samefile(dst.parent.joinpath(src)):
             return
         os.remove(dst)
-    os.symlink(src, dst)
     if platform.system() == 'Windows':
         # Resolve the absolute path for the source file
         actual_src = dst.parent.joinpath(src).resolve()


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
With the transition to Windows 11 we have seen failures on the test_security test suite consistently with error:
```
13724: Error occurred while validating local permissions: load_file_into_BIO: File could not be found, opened or is empty, path: C:/ci/ws/build/test_security/test/test_security_files/enclaves/publisher/permissions_ca.cert.pem(code: 117)
```

The proposed solution is to use hard links for Windows with a fallback to shutilcopy2 in case the linkage is across volumes, while keeping the default symlink behavior on linux. 

A hard link is not a reparse point — it is a second directory entry pointing directly to the same inode (MFT record on NTFS). When CreateFile opens a hard link, there is no reparse point to follow, no symlink to resolve. The file handle opens directly against the data. OpenSSL's fopen (regardless of static or dynamic CRT) sees a plain file.

Constraints:

- Source and destination must be on the same volume (NTFS limitation, not Windows API)
- The hard link stays valid even if the source entry is deleted (the data persists until all hard links are removed)
- It does not stay in sync if the source is replaced (unlike a symlink which always points to the current target)

The last point matters for sros2: if the CA cert in the keystore is regenerated, any hard link pointing to the old inode will serve stale content. The shutil.copy2 fallback has the same problem. This is an accepted trade-off given that cert regeneration requires re-running the full keystore creation workflow anyway.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes, Gemini Pro 3.1 for debugging and Claude Sonnet 4.6 for drafting a summary of the issue. 
See commits: 2be366b41d8e9296f33f9ce8b0ef5db8a111c8b9 
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
I'm not certain this is the right change, but it indicates that the test regressions are indeed related to the way we are interacting between container/os, bind mounts and symlinks. 
I've tested this fix and it removes the regressions:[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=27860)](https://ci.ros2.org/job/ci_windows/27860/) 

I'm checking if tweaking some permissions on the host related to symlink creation/access would render this change unnecessary, but leaving this as draft initially. 


