### PR TITLE
suppress OpenSSL legacy warning from third-party lib.

### DIFF
--- a/sros2/pytest.ini
+++ b/sros2/pytest.ini
@@ -4,3 +4,4 @@ timeout=900
 timeout_method=thread
 filterwarnings=
     ignore:.*use of fork\(\) may lead to deadlocks in the child.*
+    ignore:.*OpenSSL 3's legacy provider failed to load.*


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

filtering out the following warning, which is irrelevant to sros2 project.
the warning is emitted by the cryptography library at import time when OpenSSL 3 cannot load its legacy provider (which contains old algorithms like RC4, MD4, DES, etc.).
sros2 only uses modern algorithms, ECDSA P-256 for keys and SHA-256 for signing.
none of these live in the legacy provider, so the missing legacy provider has no functional impact.
the warning originates from a third-party library import, not from sros2 code, so suppressing it via filter warnings is the correct mechanism rather than altering sros2 logic.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

- before

```console

root@tomoyafujita-B760M-Pro-RS-D4:~/ros2_ws/colcon_ws# colcon test --event-handlers console_direct+ --packages-select sros2
Starting >>> sros2
============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.2, pluggy-1.6.0
cachedir: /root/ros2_ws/colcon_ws/build/sros2/.pytest_cache
rootdir: /root/ros2_ws/colcon_ws/src/ros2/sros2/sros2
configfile: pytest.ini
plugins: launch_testing_ros-0.30.0, launch_testing-3.10.0, ament_mypy-0.21.1, ament_xmllint-0.21.1, ament_copyright-0.21.1, ament_pep257-0.21.1, ament_flake8-0.21.1, ament_lint-0.21.1, repeat-0.9.4, timeout-2.4.0, rerunfailures-16.1, colcon-core-0.20.1, cov-5.0.0, typeguard-4.4.4, mock-3.15.1, asyncio-1.3.0
timeout: 900.0s
timeout method: thread
timeout func_only: False
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ...
collected 35 items

test/sros2/commands/security/verbs/test_create_enclave.py .........      [ 25%]
test/sros2/commands/security/verbs/test_create_keystore.py ......        [ 42%]
test/sros2/commands/security/verbs/test_create_permission.py .           [ 45%]
test/sros2/commands/security/verbs/test_generate_artifacts.py ...        [ 54%]
[Processing: sros2]
test/sros2/commands/security/verbs/test_generate_policy.py .             [ 57%]
[Processing: sros2]
test/sros2/commands/security/verbs/test_generate_policy_no_nodes.py .    [ 60%]
test/sros2/commands/security/verbs/test_list_enclaves.py ....            [ 71%]
test/sros2/commands/security/verbs/test_no_verb.py .                     [ 74%]
test/sros2/keystore/test_enclave.py ..                                   [ 80%]
test/sros2/test_utilities.py ..                                          [ 85%]
test/test_copyright.py .                                                 [ 88%]
test/test_flake8.py .                                                    [ 91%]
test/test_mypy.py .                                                      [ 94%]
test/test_pep257.py .                                                    [ 97%]
test/test_policy_to_permissions.py .                                     [100%]
------ generated xml file: /root/ros2_ws/colcon_ws/build/sros2/pytest.xml ------

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:491
  Warning: OpenSSL 3's legacy provider failed to load. Legacy algorithms will not be available. If you need those algorithms, check your OpenSSL configuration.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 35 passed, 1 warning in 85.46s (0:01:25) ===================
--- stderr: sros2

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:491
  Warning: OpenSSL 3's legacy provider failed to load. Legacy algorithms will not be available. If you need those algorithms, check your OpenSSL configuration.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---
Finished <<< sros2 [1min 29s]

Summary: 1 package finished [1min 29s]
  1 package had stderr output: sros2
```

- after

```console
root@tomoyafujita-B760M-Pro-RS-D4:~/ros2_ws/colcon_ws# colcon test --event-handlers console_direct+ --packages-select sros2
Starting >>> sros2
============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.2, pluggy-1.6.0
cachedir: /root/ros2_ws/colcon_ws/build/sros2/.pytest_cache
rootdir: /root/ros2_ws/colcon_ws/src/ros2/sros2/sros2
configfile: pytest.ini
plugins: launch_testing_ros-0.30.0, launch_testing-3.10.0, ament_mypy-0.21.1, ament_xmllint-0.21.1, ament_copyright-0.21.1, ament_pep257-0.21.1, ament_flake8-0.21.1, ament_lint-0.21.1, repeat-0.9.4, timeout-2.4.0, rerunfailures-16.1, colcon-core-0.20.1, cov-5.0.0, typeguard-4.4.4, mock-3.15.1, asyncio-1.3.0
timeout: 900.0s
timeout method: thread
timeout func_only: False
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ...
collected 35 items

test/sros2/commands/security/verbs/test_create_enclave.py .........      [ 25%]
test/sros2/commands/security/verbs/test_create_keystore.py ......        [ 42%]
test/sros2/commands/security/verbs/test_create_permission.py .           [ 45%]
test/sros2/commands/security/verbs/test_generate_artifacts.py ...        [ 54%]
[Processing: sros2]
test/sros2/commands/security/verbs/test_generate_policy.py .             [ 57%]
[Processing: sros2]
test/sros2/commands/security/verbs/test_generate_policy_no_nodes.py .    [ 60%]
test/sros2/commands/security/verbs/test_list_enclaves.py ....            [ 71%]
test/sros2/commands/security/verbs/test_no_verb.py .                     [ 74%]
test/sros2/keystore/test_enclave.py ..                                   [ 80%]
test/sros2/test_utilities.py ..                                          [ 85%]
test/test_copyright.py .                                                 [ 88%]
test/test_flake8.py .                                                    [ 91%]
[1min 24.2s] [0/1 complete] [sros2 - 1min 23.6s]
test/test_mypy.py .                                                      [ 94%]
test/test_pep257.py .                                                    [ 97%]
test/test_policy_to_permissions.py .                                     [100%]

------ generated xml file: /root/ros2_ws/colcon_ws/build/sros2/pytest.xml ------
======================== 35 passed in 85.36s (0:01:25) =========================
Finished <<< sros2 [1min 29s]

Summary: 1 package finished [1min 29s]
```

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, Claude Opus 4.8
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
